### PR TITLE
Update Doc Order of Vouchers and Campaigns API

### DIFF
--- a/docs/guides/building_blocks/Validation-Rules.md
+++ b/docs/guides/building_blocks/Validation-Rules.md
@@ -214,7 +214,7 @@ Validation rules are flexible – you can mix different limits taking into accou
 
 ## Discount per product
 
-Some validation rules are based on the structure of products in the cart. Sometimes you want to make a discount applicable only to particular items ([products](ref:get-product) and [skus](ref:get-sku)). This can be achieved with `discount_applicable` property. Once you define `applicable only to` rule by following [this guide](https://support.voucherify.io/article/53-validation-rules#applicable), the validation rule entity will look like this:
+Some validation rules are based on the structure of products in the cart. Sometimes you want to make a discount applicable only to particular items ([products](ref:get-product) and [skus](ref:get-sku)). This can be achieved with `discount_applicable` property. Once you define `applicable only to` rule by following [this guide](https://support.voucherify.io/article/148-how-to-build-a-rule#discount-specific-rule), the validation rule entity will look like this:
 
 ```json discount_applicable
 {
@@ -307,7 +307,7 @@ Voucherify enables you to assign custom attributes as metadata to products/SKUs 
 
 1. Firstly, define **custom attributes for your products** (using UI or API request) which then, can be used while creating validation rules. In the Schema, you don't attach these attributes to specific products, you just define their names, types, and values (optional). The detailed guide on how to add custom product attributes with Metadata Schema is [here](https://support.voucherify.io/article/515-products).
 
-2. When you have product metadata defined, you can **create a promo campaign with validation rules based on product metadata**. As a result, all the products in the order will be validated accordingly to the rules with product metadata. You can see how to add validation rules with product metadata in [this section](https://support.voucherify.io/article/53-validation-rules#product-metadata).
+2. When you have product metadata defined, you can **create a promo campaign with validation rules based on product metadata**. As a result, all the products in the order will be validated accordingly to the rules with product metadata. You can see how to add validation rules with product metadata in [this section](https://support.voucherify.io/article/148-how-to-build-a-rule#product-metadata).
 
 3. When the campaign is live, your customers can start redeeming codes. When creating a redemption request via API, you can **add products with metadata from scratch**. When a redemption request gets to Voucherify, metadata assigned to ordered products will be compared to the validation rules with product metadata assigned to the code. 
 

--- a/docs/reference-docs/CAMPAIGNS-API-Add-Voucher-With-Specific-Code-To-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Add-Voucher-With-Specific-Code-To-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Add Voucher with Specific Code to Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-voucher-with-specific-code-to-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Add-Vouchers-To-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Add-Vouchers-To-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Add Vouchers to Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-vouchers-to-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Create-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Create-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Create Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Delete-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Delete-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Delete Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Disable-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Disable-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Disable Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: disable-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 12
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Enable-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Enable-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Enable Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: enable-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Examine-Qualification.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Examine-Qualification.md
@@ -1,0 +1,9 @@
+---
+title: Examine Qualification
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: examine-campaigns-qualification
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Get-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Get-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Get Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Import-Vouchers-To-Campaign-Using-CSV.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Import-Vouchers-To-Campaign-Using-CSV.md
@@ -1,0 +1,9 @@
+---
+title: Import Vouchers to Campaign by CSV
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-vouchers-to-campaign-using-csv
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Import-Vouchers-To-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Import-Vouchers-To-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Import Vouchers to Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-vouchers-to-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/CAMPAIGNS-API-List-Campaigns.md
+++ b/docs/reference-docs/CAMPAIGNS-API-List-Campaigns.md
@@ -1,0 +1,9 @@
+---
+title: List Campaigns
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-campaigns
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/CAMPAIGNS-API-Update-Campaign.md
+++ b/docs/reference-docs/CAMPAIGNS-API-Update-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Update Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-campaign
+parentDoc: 639ba2658407100061f5faaf
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/VOUCHERS-API-Add-Gift-Card-Balance.md
+++ b/docs/reference-docs/VOUCHERS-API-Add-Gift-Card-Balance.md
@@ -1,0 +1,9 @@
+---
+title: Add Gift Card Balance
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-gift-voucher-balance
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/VOUCHERS-API-Create-Voucher.md
+++ b/docs/reference-docs/VOUCHERS-API-Create-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Create Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-voucher
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/VOUCHERS-API-Delete-Voucher.md
+++ b/docs/reference-docs/VOUCHERS-API-Delete-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Delete Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-voucher
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/VOUCHERS-API-Disable-Voucher.md
+++ b/docs/reference-docs/VOUCHERS-API-Disable-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Disable Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: disable-voucher
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/VOUCHERS-API-Enable-Voucher.md
+++ b/docs/reference-docs/VOUCHERS-API-Enable-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Enable Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: enable-voucher
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/VOUCHERS-API-Examine-Qualification.md
+++ b/docs/reference-docs/VOUCHERS-API-Examine-Qualification.md
@@ -1,0 +1,9 @@
+---
+title: Examine Qualification
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: examine-vouchers-qualification
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 12
+---

--- a/docs/reference-docs/VOUCHERS-API-Generate-Random-Code.md
+++ b/docs/reference-docs/VOUCHERS-API-Generate-Random-Code.md
@@ -1,0 +1,9 @@
+---
+title: Generate Random Code
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: generate-random-code
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/VOUCHERS-API-Get-Voucher.md
+++ b/docs/reference-docs/VOUCHERS-API-Get-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Get Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-voucher
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/VOUCHERS-API-Import-Vouchers-Using-CSV.md
+++ b/docs/reference-docs/VOUCHERS-API-Import-Vouchers-Using-CSV.md
@@ -1,0 +1,9 @@
+---
+title: Import Vouchers using CSV
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-vouchers-using-csv
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/VOUCHERS-API-Import-Vouchers.md
+++ b/docs/reference-docs/VOUCHERS-API-Import-Vouchers.md
@@ -1,0 +1,9 @@
+---
+title: Import Vouchers
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-vouchers
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/VOUCHERS-API-List-Vouchers.md
+++ b/docs/reference-docs/VOUCHERS-API-List-Vouchers.md
@@ -1,0 +1,9 @@
+---
+title: List Vouchers
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-vouchers
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/VOUCHERS-API-Release-Validation-Session.md
+++ b/docs/reference-docs/VOUCHERS-API-Release-Validation-Session.md
@@ -1,0 +1,9 @@
+---
+title: Release Validation Session
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: release-validation-session
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 15
+---

--- a/docs/reference-docs/VOUCHERS-API-Update-Voucher.md
+++ b/docs/reference-docs/VOUCHERS-API-Update-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Update Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-voucher
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/VOUCHERS-API-Update-Vouchers-In-Bulk.md
+++ b/docs/reference-docs/VOUCHERS-API-Update-Vouchers-In-Bulk.md
@@ -1,0 +1,9 @@
+---
+title: Update Vouchers in bulk
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-vouchers-in-bulk
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 13
+---

--- a/docs/reference-docs/VOUCHERS-API-Update-Vouchers-Metadata-In-Bulk.md
+++ b/docs/reference-docs/VOUCHERS-API-Update-Vouchers-Metadata-In-Bulk.md
@@ -1,0 +1,9 @@
+---
+title: Update Vouchers' metadata in bulk
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-vouchers-metadata-in-bulk
+parentDoc: 639ba2658407100061f5faae
+hidden: false
+order: 14
+---

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -39044,7 +39044,7 @@
     },
     "/vouchers/": {
       "post": {
-        "summary": "Create Voucher",
+        "summary": "Generate Random Code",
         "operationId": "post-vouchers",
         "responses": {
           "200": {


### PR DESCRIPTION
- Added markdown files of API endpoints to be able to manage additional content and/or change the order of the documents because readme by default organizes the endpoints in the order they appear in the OpenAPI, but sometimes we want to be able to re-order the endpoints.
- Updated links to validation documents