### PR TITLE
Add Markdown Docs for Endpoints

### DIFF
--- a/docs/reference-docs/LOYALTIES-API-Create-Loyalty-Campaign.md
+++ b/docs/reference-docs/LOYALTIES-API-Create-Loyalty-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Create Loyalty Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-loyalty-program
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/LOYALTIES-API-Delete-Loyalty-Campaign.md
+++ b/docs/reference-docs/LOYALTIES-API-Delete-Loyalty-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Delete Loyalty Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-loyalty-program
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Loyalty-Campaign.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Loyalty-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Get Loyalty Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-loyalty-program
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Loyalty-Campaigns.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Loyalty-Campaigns.md
@@ -1,0 +1,9 @@
+---
+title: List Loyalty Campaigns
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-loyalty-programs
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/LOYALTIES-API-Update-Loyalty-Campaign.md
+++ b/docs/reference-docs/LOYALTIES-API-Update-Loyalty-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Update Loyalty Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-loyalty-program
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/PROMOTIONS-API-Add-Promotion-Tier-To-Campaign.md
+++ b/docs/reference-docs/PROMOTIONS-API-Add-Promotion-Tier-To-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: Add Promotion Tier to Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-promotion-tier-to-campaign
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/PROMOTIONS-API-Create-Promotion-Stack.md
+++ b/docs/reference-docs/PROMOTIONS-API-Create-Promotion-Stack.md
@@ -1,0 +1,9 @@
+---
+title: Create Promotion Stack
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-promotion-stack
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/PROMOTIONS-API-Delete-Promotion-Stack.md
+++ b/docs/reference-docs/PROMOTIONS-API-Delete-Promotion-Stack.md
@@ -1,0 +1,9 @@
+---
+title: Delete Promotion Stack
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-promotion-stack
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 13
+---

--- a/docs/reference-docs/PROMOTIONS-API-Delete-Promotion-Tier.md
+++ b/docs/reference-docs/PROMOTIONS-API-Delete-Promotion-Tier.md
@@ -1,0 +1,9 @@
+---
+title: Delete Promotion Tier
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-promotion-tier
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/PROMOTIONS-API-Disable-Promotion-Tier.md
+++ b/docs/reference-docs/PROMOTIONS-API-Disable-Promotion-Tier.md
@@ -1,0 +1,9 @@
+---
+title: Disable Promotion Tier
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: disable-promotion-tier
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/PROMOTIONS-API-Enable-Promotion-Tier.md
+++ b/docs/reference-docs/PROMOTIONS-API-Enable-Promotion-Tier.md
@@ -1,0 +1,9 @@
+---
+title: Enable Promotion Tier
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: enable-promotion-tier
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/PROMOTIONS-API-Get-Promotion-Stack.md
+++ b/docs/reference-docs/PROMOTIONS-API-Get-Promotion-Stack.md
@@ -1,0 +1,9 @@
+---
+title: Get Promotion Stack
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-promotion-stack
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/PROMOTIONS-API-Get-Reward.md
+++ b/docs/reference-docs/PROMOTIONS-API-Get-Reward.md
@@ -1,0 +1,9 @@
+---
+title: Get Reward
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-reward
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/PROMOTIONS-API-List-Promotion-Stacks-In-Campaign.md
+++ b/docs/reference-docs/PROMOTIONS-API-List-Promotion-Stacks-In-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: List Promotion Stacks in Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-promotion-stacks-in-campaign
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/PROMOTIONS-API-List-Promotion-Stacks.md
+++ b/docs/reference-docs/PROMOTIONS-API-List-Promotion-Stacks.md
@@ -1,0 +1,9 @@
+---
+title: List Promotion Stacks
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-all-promotion-stacks
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/PROMOTIONS-API-List-Promotion-Tiers-From-Campaign.md
+++ b/docs/reference-docs/PROMOTIONS-API-List-Promotion-Tiers-From-Campaign.md
@@ -1,0 +1,9 @@
+---
+title: List Promotion Tiers from Campaign
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-promotion-tiers-from-campaign
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/PROMOTIONS-API-List-Promotion-Tiers.md
+++ b/docs/reference-docs/PROMOTIONS-API-List-Promotion-Tiers.md
@@ -1,0 +1,9 @@
+---
+title: List Promotion Tiers
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-promotion-tiers
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/PROMOTIONS-API-Update-Promotion-Stack.md
+++ b/docs/reference-docs/PROMOTIONS-API-Update-Promotion-Stack.md
@@ -1,0 +1,9 @@
+---
+title: Update Promotion Stack
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-promotion-stack
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 12
+---

--- a/docs/reference-docs/PROMOTIONS-API-Update-Promotion-Tier.md
+++ b/docs/reference-docs/PROMOTIONS-API-Update-Promotion-Tier.md
@@ -1,0 +1,9 @@
+---
+title: Update Promotion Tier
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-promotion-tier
+parentDoc: 639ba2658407100061f5fab0
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/PUBLICATIONS-API-Create-Publication.md
+++ b/docs/reference-docs/PUBLICATIONS-API-Create-Publication.md
@@ -1,0 +1,9 @@
+---
+title: Create Publication
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-publication
+parentDoc: 63b58495b5ee6800ab6535dc
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/PUBLICATIONS-API-List-Publications.md
+++ b/docs/reference-docs/PUBLICATIONS-API-List-Publications.md
@@ -1,0 +1,9 @@
+---
+title: List Publications
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-publications
+parentDoc: 63b58495b5ee6800ab6535dc
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/REDEMPTIONS-API-Get-Redemption.md
+++ b/docs/reference-docs/REDEMPTIONS-API-Get-Redemption.md
@@ -1,0 +1,9 @@
+---
+title: Get Redemption
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-redemption
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/REDEMPTIONS-API-Get-Vouchers-Redemptions.md
+++ b/docs/reference-docs/REDEMPTIONS-API-Get-Vouchers-Redemptions.md
@@ -1,0 +1,9 @@
+---
+title: Get Voucher's Redemptions
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-voucher-redemptions
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/REDEMPTIONS-API-List-Redemptions.md
+++ b/docs/reference-docs/REDEMPTIONS-API-List-Redemptions.md
@@ -1,0 +1,9 @@
+---
+title: List Redemptions
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-redemptions
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/REDEMPTIONS-API-Redeem-Promotion.md
+++ b/docs/reference-docs/REDEMPTIONS-API-Redeem-Promotion.md
@@ -1,0 +1,9 @@
+---
+title: Redeem Promotion
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: redeem-promotion
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/REDEMPTIONS-API-Redeem-Voucher-Client-Side.md
+++ b/docs/reference-docs/REDEMPTIONS-API-Redeem-Voucher-Client-Side.md
@@ -1,0 +1,9 @@
+---
+title: Redeem Voucher (client-side)
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: redeem-voucher-client-side
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/REDEMPTIONS-API-Redeem-Voucher.md
+++ b/docs/reference-docs/REDEMPTIONS-API-Redeem-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Redeem Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: redeem-voucher
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/REDEMPTIONS-API-Rollback-Redemption.md
+++ b/docs/reference-docs/REDEMPTIONS-API-Rollback-Redemption.md
@@ -1,0 +1,9 @@
+---
+title: Rollback Redemption
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: rollback-redemption
+parentDoc: 639ba2658407100061f5fab4
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/REWARDS-API-Create-Reward-Assignment.md
+++ b/docs/reference-docs/REWARDS-API-Create-Reward-Assignment.md
@@ -1,0 +1,9 @@
+---
+title: Create Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-reward-assignment
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/REWARDS-API-Create-Reward.md
+++ b/docs/reference-docs/REWARDS-API-Create-Reward.md
@@ -1,0 +1,9 @@
+---
+title: Create Reward
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-reward
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/REWARDS-API-Delete-Reward-Assignment.md
+++ b/docs/reference-docs/REWARDS-API-Delete-Reward-Assignment.md
@@ -1,0 +1,9 @@
+---
+title: Delete Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-reward-assignment
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/REWARDS-API-Delete-Reward.md
+++ b/docs/reference-docs/REWARDS-API-Delete-Reward.md
@@ -1,0 +1,9 @@
+---
+title: Delete Reward
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-reward
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/REWARDS-API-Get-Reward-Assignment.md
+++ b/docs/reference-docs/REWARDS-API-Get-Reward-Assignment.md
@@ -1,0 +1,9 @@
+---
+title: Get Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-reward-assignment
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/REWARDS-API-List-Reward-Assignments.md
+++ b/docs/reference-docs/REWARDS-API-List-Reward-Assignments.md
@@ -1,0 +1,9 @@
+---
+title: List Reward Assignments
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-reward-assignments
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/REWARDS-API-List-Rewards.md
+++ b/docs/reference-docs/REWARDS-API-List-Rewards.md
@@ -1,0 +1,9 @@
+---
+title: List Rewards
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-rewards
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/REWARDS-API-Update-Reward-Assignment.md
+++ b/docs/reference-docs/REWARDS-API-Update-Reward-Assignment.md
@@ -1,0 +1,9 @@
+---
+title: Update Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-reward-assignment
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/REWARDS-API-Update-Reward.md
+++ b/docs/reference-docs/REWARDS-API-Update-Reward.md
@@ -1,0 +1,9 @@
+---
+title: Update Reward
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-reward
+parentDoc: 639ba2658407100061f5fab1
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/STACKABLE-DISCOUNTS-API-Redeem-Stackable-Discounts.md
+++ b/docs/reference-docs/STACKABLE-DISCOUNTS-API-Redeem-Stackable-Discounts.md
@@ -1,0 +1,9 @@
+---
+title: Redeem Stackable Discounts
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: redeem-stacked-discounts
+parentDoc: 639ba2658407100061f5fab5
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/STACKABLE-DISCOUNTS-API-Rollback-Stackable-Redemptions.md
+++ b/docs/reference-docs/STACKABLE-DISCOUNTS-API-Rollback-Stackable-Redemptions.md
@@ -1,0 +1,9 @@
+---
+title: Rollback Stackable Redemptions
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: rollback-stacked-redemptions
+parentDoc: 639ba2658407100061f5fab5
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/STACKABLE-DISCOUNTS-API-Validate-Stackable-Discounts.md
+++ b/docs/reference-docs/STACKABLE-DISCOUNTS-API-Validate-Stackable-Discounts.md
@@ -1,0 +1,9 @@
+---
+title: Validate Stackable Discounts
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: validate-stacked-discounts
+parentDoc: 639ba2658407100061f5fab5
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/VALIDATIONS-API-Validate-Promotion-Tier.md
+++ b/docs/reference-docs/VALIDATIONS-API-Validate-Promotion-Tier.md
@@ -1,0 +1,9 @@
+---
+title: Validate Promotion Tier
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: validate-promotion-tier
+parentDoc: 639ba2658407100061f5fab3
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/VALIDATIONS-API-Validate-Promotions.md
+++ b/docs/reference-docs/VALIDATIONS-API-Validate-Promotions.md
@@ -1,0 +1,9 @@
+---
+title: Validate Promotions
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: validate-promotions
+parentDoc: 639ba2658407100061f5fab3
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/VALIDATIONS-API-Validate-Voucher-Client-Side.md
+++ b/docs/reference-docs/VALIDATIONS-API-Validate-Voucher-Client-Side.md
@@ -1,0 +1,9 @@
+---
+title: Validate Voucher (client-side)
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: validate-voucher-client-side
+parentDoc: 639ba2658407100061f5fab3
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/VALIDATIONS-API-Validate-Voucher.md
+++ b/docs/reference-docs/VALIDATIONS-API-Validate-Voucher.md
@@ -1,0 +1,9 @@
+---
+title: Validate Voucher
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: validate-voucher
+parentDoc: 639ba2658407100061f5fab3
+hidden: false
+order: 2
+---

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -52617,561 +52617,7 @@
         ]
       }
     },
-    "/loyalties/members/{memberId}/rewards": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "MmFAzfDe"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "Unique loyalty card assigned to a particular customer."
-        }
-      ],
-      "get": {
-        "summary": "List Member Rewards",
-        "operationId": "get-loyalties-members-memberId-rewards",
-        "responses": {
-          "200": {
-            "description": "Returns a list of rewards for the given `member_id`. Returns a filtered list if the query parameter `affordable_only` is set to `true`.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_res_list_member_rewards"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "object": "list",
-                      "data_ref": "data",
-                      "data": [
-                        {
-                          "reward": {
-                            "id": "rew_C7wS9eHFDN4CIbXI5PpLSkGY",
-                            "name": "Material Reward",
-                            "type": "MATERIAL",
-                            "parameters": {
-                              "product": {
-                                "id": "prod_0b7d7dfb05cbe5c616",
-                                "sku_id": "sku_0b7d7dfb090be5c619"
-                              }
-                            },
-                            "stock": 4,
-                            "redeemed": 1,
-                            "attributes": {
-                              "description": "Get a Comic Book in Archie's series."
-                            },
-                            "created_at": "2022-08-17T07:46:18.619169+00:00",
-                            "updated_at": "2022-08-17T08:13:48.30747+00:00",
-                            "metadata": {},
-                            "object": "reward"
-                          },
-                          "assignment": {
-                            "id": "rewa_pJYQBXSitK2OVPK3XMXZK76X",
-                            "reward_id": "rew_C7wS9eHFDN4CIbXI5PpLSkGY",
-                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
-                            "related_object_type": "campaign",
-                            "parameters": {
-                              "loyalty": {
-                                "points": 39
-                              }
-                            },
-                            "created_at": "2022-08-24T11:40:22.418972+00:00",
-                            "updated_at": "2022-08-24T13:23:50.409121+00:00",
-                            "object": "reward_assignment"
-                          },
-                          "object": "loyalty_reward"
-                        },
-                        {
-                          "reward": {
-                            "id": "rew_31M6Za6zkMRfhxYJz4aDo11h",
-                            "name": "Pay with Points",
-                            "type": "COIN",
-                            "parameters": {
-                              "coin": {
-                                "exchange_ratio": 1,
-                                "points_ratio": 1
-                              }
-                            },
-                            "stock": null,
-                            "redeemed": null,
-                            "attributes": {},
-                            "created_at": "2022-06-23T11:06:06.222736+00:00",
-                            "updated_at": null,
-                            "metadata": null,
-                            "object": "reward"
-                          },
-                          "assignment": {
-                            "id": "rewa_wrVYAfXWolq52gnl15dumPCq",
-                            "reward_id": "rew_31M6Za6zkMRfhxYJz4aDo11h",
-                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
-                            "related_object_type": "campaign",
-                            "created_at": "2022-08-11T14:13:34.581194+00:00",
-                            "updated_at": null,
-                            "object": "reward_assignment"
-                          },
-                          "object": "loyalty_reward"
-                        },
-                        {
-                          "reward": {
-                            "id": "rew_Jhq0ecLGSx8eF4pFdlhFr9P6",
-                            "name": "20% discount",
-                            "type": "CAMPAIGN",
-                            "parameters": {
-                              "campaign": {
-                                "id": "camp_4B1jDE63pCeSij3HU7gx3gPT",
-                                "type": "DISCOUNT_COUPONS"
-                              }
-                            },
-                            "stock": null,
-                            "redeemed": null,
-                            "attributes": {},
-                            "created_at": "2022-08-11T09:52:39.032699+00:00",
-                            "updated_at": null,
-                            "metadata": {},
-                            "object": "reward"
-                          },
-                          "assignment": {
-                            "id": "rewa_nFREw86qh1LiqGPRygahNh8Z",
-                            "reward_id": "rew_Jhq0ecLGSx8eF4pFdlhFr9P6",
-                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
-                            "related_object_type": "campaign",
-                            "parameters": {
-                              "loyalty": {
-                                "points": 100
-                              }
-                            },
-                            "created_at": "2022-08-11T14:13:34.581194+00:00",
-                            "updated_at": null,
-                            "object": "reward_assignment"
-                          },
-                          "object": "loyalty_reward"
-                        },
-                        {
-                          "reward": {
-                            "id": "rew_Dev2yQLodRV33UKPKHTUQWk1",
-                            "name": "Get a product",
-                            "type": "MATERIAL",
-                            "parameters": {
-                              "product": {
-                                "id": "prod_0b2ac1dab28985cb1e",
-                                "sku_id": null
-                              }
-                            },
-                            "stock": 1,
-                            "redeemed": 1,
-                            "attributes": {
-                              "description": "Product"
-                            },
-                            "created_at": "2022-06-13T10:43:15.929621+00:00",
-                            "updated_at": "2022-08-11T15:59:30.820937+00:00",
-                            "metadata": null,
-                            "object": "reward"
-                          },
-                          "assignment": {
-                            "id": "rewa_SV4gMgPXTXDrsoTyqhY1B2ut",
-                            "reward_id": "rew_Dev2yQLodRV33UKPKHTUQWk1",
-                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
-                            "related_object_type": "campaign",
-                            "parameters": {
-                              "loyalty": {
-                                "points": 4000
-                              }
-                            },
-                            "created_at": "2022-08-11T14:13:34.581194+00:00",
-                            "updated_at": null,
-                            "object": "reward_assignment"
-                          },
-                          "object": "loyalty_reward"
-                        },
-                        {
-                          "reward": {
-                            "id": "rew_oQEYtUNYcVe2IdBEUBdLfkCD",
-                            "name": "Get a comic book",
-                            "type": "MATERIAL",
-                            "parameters": {
-                              "product": {
-                                "id": "prod_0b7d7dfb05cbe5c616",
-                                "sku_id": null
-                              }
-                            },
-                            "stock": 1,
-                            "redeemed": 2,
-                            "attributes": {
-                              "image_url": "https://voucherify-uploads.s3.amazonaws.com/org_2qt8DYlM/img_fPH9ohe0pZf4EiIt295sk9Ob.png",
-                              "description": "Archie's Series"
-                            },
-                            "created_at": "2022-08-11T14:35:44.694611+00:00",
-                            "updated_at": "2022-08-17T07:52:56.965366+00:00",
-                            "metadata": {
-                              "Type": "GR-2"
-                            },
-                            "object": "reward"
-                          },
-                          "assignment": {
-                            "id": "rewa_7HHH6TjN7Q9WDr5ZePeZUg5p",
-                            "reward_id": "rew_oQEYtUNYcVe2IdBEUBdLfkCD",
-                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
-                            "related_object_type": "campaign",
-                            "parameters": {
-                              "loyalty": {
-                                "points": 10
-                              }
-                            },
-                            "created_at": "2022-08-11T15:44:12.789086+00:00",
-                            "updated_at": null,
-                            "object": "reward_assignment"
-                          },
-                          "object": "loyalty_reward"
-                        }
-                      ],
-                      "total": 5
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          },
-          {
-            "in": "query",
-            "name": "affordable_only",
-            "description": "Limit the results to rewards that the customer can actually afford (only rewards whose price in points is not higher than the loyalty points balance on a loyalty card). Set this flag to `true` to return rewards which the customer can actually afford.",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "description": "Retrieves the list of rewards that the given customer (identified by `member_id`, which is a loyalty card assigned to a particular customer) **can get in exchange for loyalty points**.  \n\nYou can use the `affordable_only` parameter to limit the results to rewards that the customer can actually afford (only rewards whose price in points is not higher than the loyalty points balance on a loyalty card).  \n\nPlease note that rewards that are disabled (i.e. set to `Not Available` in the Dashboard) for a given loyalty tier reward mapping will not be returned in this endpoint.",
-        "tags": [
-          "LOYALTIES API"
-        ]
-      }
-    },
-    "/loyalties/{campaignId}/reward-assignments/{assignmentId}/reward": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "camp_pqZjuhG6Mgtp4GD0zD7b8hA3"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
-        },
-        {
-          "schema": {
-            "type": "string",
-            "example": "rewa_hzc19a5NLyIr2bVL3UB1w0B3"
-          },
-          "name": "assignmentId",
-          "in": "path",
-          "required": true,
-          "description": "Unique reward assignment ID."
-        }
-      ],
-      "get": {
-        "summary": "Get Reward Details",
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns reward details in the context of a loyalty *campaign* and reward assignment ID.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/4_obj_reward_object"
-                },
-                "examples": {
-                  "Material": {
-                    "value": {
-                      "id": "rew_Dev2yQLodRV33UKPKHTUQWk1",
-                      "name": "Get a product",
-                      "type": "MATERIAL",
-                      "parameters": {
-                        "product": {
-                          "id": "prod_0b2ac1dab28985cb1e",
-                          "sku_id": null
-                        }
-                      },
-                      "stock": "1",
-                      "redeemed": "1",
-                      "attributes": {
-                        "description": "Product"
-                      },
-                      "created_at": "2022-06-13T10:43:15.929Z",
-                      "updated_at": "2022-08-11T15:59:30.820Z",
-                      "metadata": null,
-                      "object": "reward"
-                    }
-                  },
-                  "Pay with Points": {
-                    "value": {
-                      "id": "rew_31M6Za6zkMRfhxYJz4aDo11h",
-                      "name": "Pay with Points",
-                      "type": "COIN",
-                      "parameters": {
-                        "coin": {
-                          "exchange_ratio": 1,
-                          "points_ratio": 1
-                        }
-                      },
-                      "stock": null,
-                      "redeemed": null,
-                      "attributes": {},
-                      "created_at": "2022-06-23T11:06:06.222Z",
-                      "updated_at": null,
-                      "metadata": null,
-                      "object": "reward"
-                    }
-                  },
-                  "Discount Coupon": {
-                    "value": {
-                      "id": "rew_Jhq0ecLGSx8eF4pFdlhFr9P6",
-                      "name": "20% discount",
-                      "type": "CAMPAIGN",
-                      "parameters": {
-                        "campaign": {
-                          "id": "camp_4B1jDE63pCeSij3HU7gx3gPT",
-                          "type": "DISCOUNT_COUPONS"
-                        }
-                      },
-                      "stock": null,
-                      "redeemed": null,
-                      "attributes": {},
-                      "created_at": "2022-08-11T09:52:39.032Z",
-                      "updated_at": null,
-                      "metadata": {},
-                      "object": "reward"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-loyalties-campaignId-reward-assignments-assignmentId-reward",
-        "description": "Get reward details in the context of a loyalty campaign and reward assignment ID.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ]
-      }
-    },
-    "/loyalties/{campaignId}/reward-assignments": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "camp_pqZjuhG6Mgtp4GD0zD7b8hA3"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
-        }
-      ],
-      "get": {
-        "summary": "List Reward Assignments",
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "operationId": "get-loyalties-campaignId-reward-assignments",
-        "description": "Returns reward assignments from a given loyalty campaign.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          },
-          {
-            "$ref": "#/components/parameters/limit"
-          },
-          {
-            "$ref": "#/components/parameters/page"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "example": "rewa_m9hEAu10KsPcLhGXiHG85aY0"
-            },
-            "in": "query",
-            "name": "assignmentId",
-            "description": "A unique reward assignment ID."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns a dictionary with reward assignment objects.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_res_list_reward_assignments"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "object": "list",
-                      "data_ref": "data",
-                      "data": [
-                        {
-                          "id": "rewa_2EPffrq151ArmjR7j3CumxGE",
-                          "reward_id": "rew_6uCtsIjgcuzi4NW43mKZQWd5",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 18
-                            }
-                          },
-                          "created_at": "2022-06-22T11:02:19.564Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_75e6oBjYfIKUDbM4Dsgg6xAU",
-                          "reward_id": "rew_gI4GYbXMeHAJUAIiZCad5LaS",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 25
-                            }
-                          },
-                          "created_at": "2022-06-22T11:00:49.034Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_dJ5nFBpmL8DVhmY1j4zYYOqF",
-                          "reward_id": "rew_VSi5rNvb67bn2tqkNwVBBP7u",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 100
-                            }
-                          },
-                          "created_at": "2022-06-22T10:57:24.051Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_874iVl5bHrZFr2FSsG9ilKzF",
-                          "reward_id": "rew_QQ73sIywuMoEj6L8K6ft2Mn7",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "created_at": "2022-06-22T10:47:55.934Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_GgSlEk4bnR09lMMts6CgR6aV",
-                          "reward_id": "rew_URQeO2fgbjxHnulgYVguuidX",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 9
-                            }
-                          },
-                          "created_at": "2022-06-22T10:21:53.109Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_i6VcsXr3ovJ2JCpZk9k1JOj1",
-                          "reward_id": "rew_YNr7tRr9TPAiFEJBZBAsuKCq",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "created_at": "2022-06-22T10:18:27.684Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_YjTw2InYSVx1nA88brDASS9e",
-                          "reward_id": "rew_BUfchmIo7pOR8GrZMw0vVL08",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 30
-                            }
-                          },
-                          "created_at": "2022-06-22T09:58:12.133Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
-                          "reward_id": "rew_injbwG52POgfpSogTlQl4hA6",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 10
-                            }
-                          },
-                          "created_at": "2022-06-13T11:56:49.185Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_gb6U5byuRh12EvdiL46P4Cxy",
-                          "reward_id": "rew_NQB7WbdQLBrFQW1DZmBNcLvH",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 100
-                            }
-                          },
-                          "created_at": "2022-06-13T11:50:23.429Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_hfyF9IGez9i3z5a3Uwlkcg7S",
-                          "reward_id": "rew_87ItIc9P5Bky10eS7vEm7Dc7",
-                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 20
-                            }
-                          },
-                          "created_at": "2022-06-13T11:20:43.961Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        }
-                      ],
-                      "total": 12
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/loyalties/{campaignId}/rewards": {
+    "/loyalties/{campaignId}/members": {
       "parameters": [
         {
           "schema": {
@@ -53180,67 +52626,132 @@
           "name": "campaignId",
           "in": "path",
           "required": true,
-          "description": "Unique campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+          "description": "Unique campaign ID of the loyalty program from which you want to assign a loyalty card."
         }
       ],
       "get": {
-        "summary": "List Reward Assignments",
+        "summary": "List Members",
         "tags": [
           "LOYALTIES API"
         ],
         "responses": {
           "200": {
-            "description": "Returns a dictionary with reward assignment objects.",
+            "description": "Returns a list of loyalty cards within a campaign.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_list_reward_assignments"
+                  "$ref": "#/components/schemas/8_res_list_members"
                 },
                 "examples": {
                   "Example": {
                     "value": {
                       "object": "list",
-                      "data_ref": "data",
-                      "data": [
+                      "data_ref": "vouchers",
+                      "vouchers": [
                         {
-                          "id": "rewa_6VSWcXjfm5PuZlfeuZxl5JZT",
-                          "reward_id": "rew_pjJKIZgjIopIPZyibEAt7oPk",
-                          "related_object_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "related_object_type": "campaign",
-                          "created_at": "2022-08-30T08:24:32.171Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
-                        },
-                        {
-                          "id": "rewa_7gFZsNg8oiry63FtzML0N52R",
-                          "reward_id": "rew_BUfchmIo7pOR8GrZMw0vVL08",
-                          "related_object_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 3000000
+                          "id": "v_YLn0WVWXSXbUfDvxgrgUbtfJ3SQIY655",
+                          "code": "0PmQ7JQI",
+                          "campaign": "Loyalty Campaign",
+                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "category": null,
+                          "category_id": null,
+                          "categories": [],
+                          "type": "LOYALTY_CARD",
+                          "discount": null,
+                          "gift": null,
+                          "loyalty_card": {
+                            "points": 0,
+                            "balance": 0
+                          },
+                          "start_date": null,
+                          "expiration_date": null,
+                          "validity_timeframe": null,
+                          "validity_day_of_week": null,
+                          "active": true,
+                          "additional_info": null,
+                          "metadata": {},
+                          "assets": {
+                            "qr": {
+                              "id": "U2FsdGVkX19RtPewWeUYb2hiCR6xEhVE3SLdMfCXj3BA/s6uqSwFl2oAKAt9K5dolsdcZcj5Jgaa/YCnKkm63TRuX6OgGJoEggbKMg+wLfCMwBSi4J2v8KXuyqM25wP4r9WAL58Z+z3B1jkALIbjtw==",
+                              "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX19RtPewWeUYb2hiCR6xEhVE3SLdMfCXj3BA%2Fs6uqSwFl2oAKAt9K5dolsdcZcj5Jgaa%2FYCnKkm63TRuX6OgGJoEggbKMg%2BwLfCMwBSi4J2v8KXuyqM25wP4r9WAL58Z%2Bz3B1jkALIbjtw%3D%3D"
+                            },
+                            "barcode": {
+                              "id": "U2FsdGVkX1+hrRfaPMHRRX5aGVz2RpurRBjC2brcHcptPs4Od93qZM51vUXZe4DDzfRbnVrP+BfBtF+pyyQpxCeqbQuB/OuSnP/nzec6n0n/gTb9+XcIYLvvxcbnDbYoVdRFQEbcCxKKo4QzDlqIjQ==",
+                              "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2BhrRfaPMHRRX5aGVz2RpurRBjC2brcHcptPs4Od93qZM51vUXZe4DDzfRbnVrP%2BBfBtF%2BpyyQpxCeqbQuB%2FOuSnP%2Fnzec6n0n%2FgTb9%2BXcIYLvvxcbnDbYoVdRFQEbcCxKKo4QzDlqIjQ%3D%3D"
                             }
                           },
-                          "created_at": "2022-05-13T11:14:58.146Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
+                          "is_referral_code": false,
+                          "created_at": "2022-04-15T05:48:45.509Z",
+                          "updated_at": "2022-07-01T00:01:57.860Z",
+                          "holder_id": "cust_nk0N1uNQ1YnupAoJGOgvsODC",
+                          "redemption": {
+                            "quantity": null,
+                            "redeemed_quantity": 0,
+                            "redeemed_points": 0,
+                            "object": "list",
+                            "url": "/v1/vouchers/0PmQ7JQI/redemptions?page=1&limit=10"
+                          },
+                          "publish": {
+                            "object": "list",
+                            "count": 1,
+                            "url": "/v1/vouchers/0PmQ7JQI/publications?page=1&limit=10"
+                          },
+                          "object": "voucher"
                         },
                         {
-                          "id": "rewa_eAGhQSY4FS4T3q4zMkiarHoN",
-                          "reward_id": "rew_nIy4gHpQHle2c3pNMwuj7G6j",
-                          "related_object_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "related_object_type": "campaign",
-                          "parameters": {
-                            "loyalty": {
-                              "points": 100
+                          "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                          "code": "MmFAzfDe",
+                          "campaign": "Loyalty Campaign",
+                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "category": null,
+                          "category_id": "cat_0b6152ce12414820de",
+                          "categories": [],
+                          "type": "LOYALTY_CARD",
+                          "discount": null,
+                          "gift": null,
+                          "loyalty_card": {
+                            "points": 13435,
+                            "balance": 13135,
+                            "next_expiration_date": "2022-11-30",
+                            "next_expiration_points": 12
+                          },
+                          "start_date": null,
+                          "expiration_date": null,
+                          "validity_timeframe": null,
+                          "validity_day_of_week": null,
+                          "active": true,
+                          "additional_info": null,
+                          "metadata": {},
+                          "assets": {
+                            "qr": {
+                              "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
+                              "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
+                            },
+                            "barcode": {
+                              "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
+                              "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
                             }
                           },
-                          "created_at": "2022-02-28T11:56:55.241Z",
-                          "updated_at": null,
-                          "object": "reward_assignment"
+                          "is_referral_code": false,
+                          "created_at": "2022-02-18T14:03:59.954Z",
+                          "updated_at": "2022-11-21T13:49:54.949Z",
+                          "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
+                          "redemption": {
+                            "quantity": null,
+                            "redeemed_quantity": 1,
+                            "redeemed_points": 300,
+                            "object": "list",
+                            "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
+                          },
+                          "publish": {
+                            "object": "list",
+                            "count": 1,
+                            "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
+                          },
+                          "object": "voucher"
                         }
                       ],
-                      "total": 3
+                      "total": 2
                     }
                   }
                 }
@@ -53248,8 +52759,7 @@
             }
           }
         },
-        "operationId": "get-loyalties-campaignId-rewards",
-        "description": "Returns active <!-- [rewards](OpenAPI.json/components/schemas/4_obj_reward_object) -->rewards from a given loyalty campaign.",
+        "operationId": "get-loyalties-campaignId-members",
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -53264,375 +52774,130 @@
             "$ref": "#/components/parameters/page"
           },
           {
+            "$ref": "#/components/parameters/created_at"
+          },
+          {
+            "$ref": "#/components/parameters/updated_at"
+          },
+          {
             "schema": {
               "type": "string",
-              "example": "rewa_m9hEAu10KsPcLhGXiHG85aY0"
+              "enum": [
+                "created_at",
+                "-created_at",
+                "updated_at",
+                "-updated_at"
+              ]
             },
             "in": "query",
-            "name": "assignment_id",
-            "description": "A unique reward assignment ID."
+            "name": "order",
+            "description": "Sorts the results using one of the filtering options, where the dash - preceding a sorting option means sorting in a descending order."
           }
-        ]
+        ],
+        "description": "Returns a list of your loyalty cards. The loyalty cards are sorted by creation date, with the most recent loyalty cards appearing first."
       },
       "post": {
-        "summary": "Create Reward Assignment",
-        "operationId": "post-loyalties-campaignId-rewards",
+        "summary": "Add Member",
+        "operationId": "post-loyalties-campaignId-members",
         "responses": {
           "200": {
-            "description": "Returns a list of reward assignment objects.",
+            "description": "Returns the voucher object that was published to the customer provided in the request payload.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_create_reward_assignment"
+                  "$ref": "#/components/schemas/8_obj_loyalty_card_object"
                 },
                 "examples": {
-                  "Example": {
-                    "value": [
-                      {
-                        "id": "rewa_Iw9VopmlLm0topBG17ZH1gp5",
-                        "reward_id": "rew_wg2pvCr5LDhCq4uVQZ9LhuZm",
-                        "related_object_id": "camp_fkZ28pe7DUAEmmabofkxHI8N",
-                        "related_object_type": "campaign",
-                        "parameters": {
-                          "loyalty": {
-                            "points": 2
-                          }
+                  "Loyalty Card": {
+                    "value": {
+                      "id": "v_0TxKw1bm0oZuS5lwA8526vze1OBMV1OH",
+                      "code": "KpzbHUY5",
+                      "campaign": "Loyalty Campaign",
+                      "campaign_id": "camp_eTIsUtuzkRXQT6rsUQqrS5Gw",
+                      "category": "New Customers",
+                      "category_id": "cat_0b6152ce12414820dc",
+                      "categories": [
+                        {
+                          "id": "cat_0b6152ce12414820dc",
+                          "name": "New Customers",
+                          "hierarchy": 0,
+                          "created_at": "2022-07-14T20:17:07.657Z",
+                          "object": "category"
+                        }
+                      ],
+                      "type": "LOYALTY_CARD",
+                      "discount": null,
+                      "gift": null,
+                      "loyalty_card": {
+                        "points": 0,
+                        "balance": 0
+                      },
+                      "start_date": null,
+                      "expiration_date": null,
+                      "validity_timeframe": null,
+                      "validity_day_of_week": null,
+                      "active": true,
+                      "additional_info": null,
+                      "metadata": {
+                        "Season": "Fall"
+                      },
+                      "assets": {
+                        "qr": {
+                          "id": "U2FsdGVkX1+hdZfzUaz448vIsyf7WpvXiDyqFbyw0+P5wMu12w3B5DyYwA7LCSK+Nr7TA7PKGuHOTGxfBieqrhvJo81HiaIJimDOhk+ecEOisMRmHf6XsNckVlyBHmkpBiXWNm8UDwZnXOAG75Usdw==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX1%2BhdZfzUaz448vIsyf7WpvXiDyqFbyw0%2BP5wMu12w3B5DyYwA7LCSK%2BNr7TA7PKGuHOTGxfBieqrhvJo81HiaIJimDOhk%2BecEOisMRmHf6XsNckVlyBHmkpBiXWNm8UDwZnXOAG75Usdw%3D%3D"
                         },
-                        "created_at": "2022-11-28T18:54:19.747Z",
-                        "updated_at": null,
-                        "object": "reward_assignment"
-                      },
-                      {
-                        "id": "rewa_tAFZ7cHiTwZyOg1QaWHt6yYv",
-                        "reward_id": "rew_z35ffKoH0tCcck8EL56p6SIs",
-                        "related_object_id": "camp_fkZ28pe7DUAEmmabofkxHI8N",
-                        "related_object_type": "campaign",
-                        "parameters": {
-                          "loyalty": {
-                            "points": 2
-                          }
-                        },
-                        "created_at": "2022-11-28T18:54:19.747Z",
-                        "updated_at": null,
-                        "object": "reward_assignment"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Returns an error if there's a reward assignment created for the given reward.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/e_409_duplicate_found"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "code": 409,
-                      "key": "duplicate_found",
-                      "message": "Duplicated resource found",
-                      "details": "Duplicated reward_assignment exists with id rewa_50O40FgyojhUiZAs3vDQbKiC",
-                      "request_id": "v-0c11a10ed2ce676da9",
-                      "resource_id": "rewa_50O40FgyojhUiZAs3vDQbKiC",
-                      "resource_type": "reward_assignment"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_create_reward_assignment"
-              },
-              "examples": {
-                "Example": {
-                  "value": [
-                    {
-                      "reward": "rew_wg2pvCr5LDhCq4uVQZ9LhuZm",
-                      "parameters": {
-                        "loyalty": {
-                          "points": 2
-                        }
-                      }
-                    },
-                    {
-                      "reward": "rew_z35ffKoH0tCcck8EL56p6SIs",
-                      "parameters": {
-                        "loyalty": {
-                          "points": 2
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "description": "Define the cost of the rewards in loyalty points."
-        },
-        "description": "Add <!-- [rewards](OpenAPI.json/components/schemas/4_obj_reward_object) -->rewards to a loyalty campaign."
-      }
-    },
-    "/loyalties/{campaignId}/reward-assignments/{assignmentId}": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "camp_pqZjuhG6Mgtp4GD0zD7b8hA3"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
-        },
-        {
-          "schema": {
-            "type": "string",
-            "example": "rewa_hzc19a5NLyIr2bVL3UB1w0B3"
-          },
-          "name": "assignmentId",
-          "in": "path",
-          "required": true,
-          "description": "Unique reward assignment ID."
-        }
-      ],
-      "get": {
-        "summary": "Get Reward Assignment",
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns specific reward assignment.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/4_obj_reward_assignment_object"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
-                      "reward_id": "rew_injbwG52POgfpSogTlQl4hA6",
-                      "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                      "related_object_type": "campaign",
-                      "parameters": {
-                        "loyalty": {
-                          "points": 10
+                        "barcode": {
+                          "id": "U2FsdGVkX19VRXApVvZ9/ArwBd0wNg7s2KZBXrFvPXZdDQyzGj0HbbEIx5TAoXNR9zaE5kzIj9BElzgK82aOMMVnc1sqvr93xw+YeYMnqGqHRZfM78pYC8560Zc3U6IELtxzaJJ0x2uDUe6Dc9XYeg==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX19VRXApVvZ9%2FArwBd0wNg7s2KZBXrFvPXZdDQyzGj0HbbEIx5TAoXNR9zaE5kzIj9BElzgK82aOMMVnc1sqvr93xw%2BYeYMnqGqHRZfM78pYC8560Zc3U6IELtxzaJJ0x2uDUe6Dc9XYeg%3D%3D"
                         }
                       },
-                      "created_at": "2022-06-13T11:56:49.185Z",
-                      "updated_at": null,
-                      "object": "reward_assignment"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-loyalties-campaignId-reward-assignments-assignmentId",
-        "description": "Retrieve specific reward assignment.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ]
-      }
-    },
-    "/loyalties/{campaignId}/rewards/{assignmentId}": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "camp_0dJG7cCAjquzcxWmZ634bA0C"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
-        },
-        {
-          "schema": {
-            "type": "string",
-            "example": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH"
-          },
-          "name": "assignmentId",
-          "in": "path",
-          "required": true,
-          "description": "A unique reward assignment ID."
-        }
-      ],
-      "put": {
-        "summary": "Update Reward Assignment",
-        "operationId": "put-loyalties-campaignId-rewards-assignmentId",
-        "responses": {
-          "200": {
-            "description": "Returns a reward assignment with an updated points value.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/4_obj_reward_assignment_object"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "id": "rewa_Iw9VopmlLm0topBG17ZH1gp5",
-                      "reward_id": "rew_wg2pvCr5LDhCq4uVQZ9LhuZm",
-                      "related_object_id": "camp_fkZ28pe7DUAEmmabofkxHI8N",
-                      "related_object_type": "campaign",
-                      "parameters": {
-                        "loyalty": {
-                          "points": 3
-                        }
+                      "is_referral_code": false,
+                      "created_at": "2022-11-21T15:48:57.860Z",
+                      "updated_at": "2022-11-21T15:49:36.671Z",
+                      "holder_id": "cust_8KQmHxAERpgebYcFhSpZRr37",
+                      "redemption": {
+                        "quantity": null,
+                        "redeemed_quantity": 0,
+                        "redeemed_points": 0,
+                        "object": "list",
+                        "url": "/v1/vouchers/KpzbHUY5/redemptions?page=1&limit=10"
                       },
-                      "created_at": "2022-11-28T18:54:19.747Z",
-                      "updated_at": "2022-11-28T19:27:40.604Z",
-                      "object": "reward_assignment"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "description": "Updates rewards parameters, i.e. the points cost for the specific reward.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_update_reward_assignment"
-              },
-              "examples": {
-                "Example": {
-                  "value": {
-                    "parameters": {
-                      "loyalty": {
-                        "points": 3
-                      }
+                      "publish": {
+                        "object": "list",
+                        "count": 1,
+                        "url": "/v1/vouchers/KpzbHUY5/publications?page=1&limit=10"
+                      },
+                      "object": "voucher"
                     }
                   }
                 }
               }
             }
           },
-          "description": "Update the points cost for the reward assignment."
-        }
-      },
-      "delete": {
-        "summary": "Delete Reward Assignment",
-        "operationId": "delete-loyalties-campaignId-rewards-assignmentId",
-        "responses": {
-          "204": {
-            "description": "Returns no content if deletion is successful."
-          },
-          "404": {
-            "description": "Returns an error indicating that the loyalty campaign or reward assignment with given ID was not found.",
+          "400": {
+            "description": "Returns an error.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/e_404_not_found"
+                  "$ref": "#/components/schemas/e_error_no_translation"
                 },
                 "examples": {
-                  "Reward Assignment Not Found": {
+                  "No Voucher Suitable for Publication": {
                     "value": {
-                      "code": 404,
-                      "key": "not_found",
-                      "message": "Resource not found",
-                      "details": "Cannot find reward_assignment with id rewa_0b4hqJpVFssxXXrq56Ddtyo",
-                      "request_id": "v-0ae2b69e0cd0c1364f",
-                      "resource_id": "rewa_0b4hqJpVFssxXXrq56Ddtyo",
-                      "resource_type": "reward_assignment"
+                      "code": 400,
+                      "key": "no_voucher_suitable_for_publication",
+                      "message": "Couldn't find any voucher suitable for publication",
+                      "details": "Couldn't create new vouchers for publication",
+                      "request_id": "v-0c086598620e6704dd"
                     }
                   },
-                  "Loyalty Campaign Not Found": {
+                  "Voucher already published": {
                     "value": {
-                      "code": 404,
-                      "key": "not_found",
-                      "message": "Resource not found",
-                      "details": "Cannot find campaign with id Loyalty Summer Campaign",
-                      "request_id": "v-0ae2b71e57d027e263",
-                      "resource_id": "Loyalty Summer Campaign",
-                      "resource_type": "campaign"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "description": "This method deletes a reward assignment for a particular loyalty campaign."
-      },
-      "get": {
-        "summary": "Get Reward Assignment",
-        "operationId": "get-loyalties-campaignId-rewards-assignmentId",
-        "responses": {
-          "200": {
-            "description": "Returns specific reward assignment.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/4_obj_reward_assignment_object"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
-                      "reward_id": "rew_injbwG52POgfpSogTlQl4hA6",
-                      "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
-                      "related_object_type": "campaign",
-                      "parameters": {
-                        "loyalty": {
-                          "points": 10
-                        }
-                      },
-                      "created_at": "2022-06-13T11:56:49.185Z",
-                      "updated_at": null,
-                      "object": "reward_assignment"
+                      "code": 400,
+                      "key": "voucher_already_published",
+                      "message": "Voucher already published",
+                      "details": "Voucher 'v_ZFjKHQD0d56eMkWkrotJaVbiMuXClRuM' has already been published",
+                      "request_id": "v-0c086aaa7dc24ccfe0"
                     }
                   }
                 }
@@ -53640,7 +52905,7 @@
             }
           },
           "404": {
-            "description": "Returns an error if the reward assignment cannot be found.",
+            "description": "Returns an error if the voucher code that was specified in the request payload is not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -53652,10 +52917,10 @@
                       "code": 404,
                       "key": "not_found",
                       "message": "Resource not found",
-                      "details": "Cannot find reward_assignment with id rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
-                      "request_id": "v-0c0be6ee648e67609b",
-                      "resource_id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
-                      "resource_type": "reward_assignment"
+                      "details": "Cannot find voucher with id Loyalty_Card",
+                      "request_id": "v-0c086a26de424ccf2f",
+                      "resource_id": "Loyalty_Card",
+                      "resource_type": "voucher"
                     }
                   }
                 }
@@ -53666,7 +52931,6 @@
         "tags": [
           "LOYALTIES API"
         ],
-        "description": "Retrieve specific reward assignment.",
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -53674,10 +52938,271 @@
           {
             "$ref": "#/components/parameters/X-App-Token"
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_add_member"
+              },
+              "examples": {
+                "Using source ID": {
+                  "value": {
+                    "customer": "source_customer_1",
+                    "metadata": {
+                      "year": 2022
+                    },
+                    "channel": "postman",
+                    "voucher": "KpzbHUY5"
+                  }
+                },
+                "Using unique Voucherify assigned ID": {
+                  "value": {
+                    "customer": "cust_8KQmHxAERpgebYcFhSpZRr37",
+                    "metadata": {
+                      "year": 2022
+                    },
+                    "channel": "postman",
+                    "voucher": "KpzbHUY5"
+                  }
+                },
+                "Using source ID in object": {
+                  "value": {
+                    "customer": {
+                      "source_id": "source_customer_1"
+                    },
+                    "metadata": {
+                      "year": 2022
+                    },
+                    "channel": "postman",
+                    "voucher": "KpzbHUY5"
+                  }
+                },
+                "Using unique Voucherify assigned ID in object": {
+                  "value": {
+                    "customer": {
+                      "id": "cust_8KQmHxAERpgebYcFhSpZRr37"
+                    },
+                    "metadata": {
+                      "year": 2022
+                    },
+                    "channel": "postman",
+                    "voucher": "KpzbHUY5"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Provide details to whom the loyalty card should be assigned.    \n\nYou can choose to either specify the exact loyalty card code that you want to publish from existin (non-assigned) codes, or choose not to specify a voucher code. If you choose not to specify a code in the request paylaod, then the system will choose the next available voucher code available to be assigned to a customer.  \n\nYou can also include metadata in the request payload. This metadata will be assigned to the publication object, but will not be returned in the response to this endpoint. To see of publications (assignments of particular codes to customers) and publication metadata, use the <!-- [List Publications](OpenAPI.json/paths/~1publications/get) -->[List Publications](ref:list-publications) endpoint."
+        },
+        "description": "This method assigns a loyalty card to a customer. It selects a <!-- [loyalty card](OpenAPI.json/components/schemas/1_obj_voucher_object) -->[loyalty card](ref:get-voucher) suitable for publication, adds a publish entry, and returns the published voucher.  \n\nA voucher is suitable for publication when it's active and hasn't been published yet.  \n\n<!-- theme: info -->\n\n> #### Auto-update campaign\n>\n> In case you want to ensure the number of publishable codes increases automatically with the number of customers, you should use **auto-update** campaign.\n\n\n"
+      }
+    },
+    "/loyalties/{campaignId}/members/{memberId}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "Unique campaign ID."
+        },
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "memberId",
+          "in": "path",
+          "required": true,
+          "description": "Unique code that identifies the loyalty card."
+        }
+      ],
+      "get": {
+        "summary": "Get Member",
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns loyalty card details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_obj_loyalty_card_object_non_expanded_categories"
+                },
+                "examples": {
+                  "Loyalty Card": {
+                    "value": {
+                      "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                      "code": "MmFAzfDe",
+                      "campaign": "Loyalty Program",
+                      "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                      "category": null,
+                      "category_id": "cat_0b6152ce12414820de",
+                      "categories": [],
+                      "type": "LOYALTY_CARD",
+                      "discount": null,
+                      "gift": null,
+                      "loyalty_card": {
+                        "points": 13435,
+                        "balance": 13135,
+                        "next_expiration_date": "2022-11-30",
+                        "next_expiration_points": 12
+                      },
+                      "start_date": null,
+                      "expiration_date": null,
+                      "validity_timeframe": null,
+                      "validity_day_of_week": null,
+                      "active": true,
+                      "additional_info": null,
+                      "metadata": {},
+                      "assets": {
+                        "qr": {
+                          "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
+                        },
+                        "barcode": {
+                          "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
+                        }
+                      },
+                      "is_referral_code": false,
+                      "created_at": "2022-02-18T14:03:59.954Z",
+                      "updated_at": "2022-11-21T13:49:54.949Z",
+                      "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
+                      "redemption": {
+                        "quantity": null,
+                        "redeemed_quantity": 1,
+                        "redeemed_points": 300,
+                        "object": "list",
+                        "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
+                      },
+                      "publish": {
+                        "object": "list",
+                        "count": 1,
+                        "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
+                      },
+                      "object": "voucher"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-loyalties-campaignId-members-memberId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "description": "Retrieves the loyalty card with the given member ID (i.e. voucher code)."
+      }
+    },
+    "/loyalties/members/{memberId}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "MmFAzfDe"
+          },
+          "name": "memberId",
+          "in": "path",
+          "required": true,
+          "description": "Unique loyalty card code assigned to a particular customer."
+        }
+      ],
+      "get": {
+        "summary": "Get Member",
+        "operationId": "get-loyalties-members-memberId",
+        "responses": {
+          "200": {
+            "description": "Returns loyalty card details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_obj_loyalty_card_object_non_expanded_categories"
+                },
+                "examples": {
+                  "Loyalty Card": {
+                    "value": {
+                      "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                      "code": "MmFAzfDe",
+                      "campaign": "Loyalty Program",
+                      "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                      "category": null,
+                      "category_id": "cat_0b6152ce12414820de",
+                      "categories": [],
+                      "type": "LOYALTY_CARD",
+                      "discount": null,
+                      "gift": null,
+                      "loyalty_card": {
+                        "points": 13435,
+                        "balance": 13135,
+                        "next_expiration_date": "2022-11-30",
+                        "next_expiration_points": 12
+                      },
+                      "start_date": null,
+                      "expiration_date": null,
+                      "validity_timeframe": null,
+                      "validity_day_of_week": null,
+                      "active": true,
+                      "additional_info": null,
+                      "metadata": {},
+                      "assets": {
+                        "qr": {
+                          "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
+                        },
+                        "barcode": {
+                          "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
+                        }
+                      },
+                      "is_referral_code": false,
+                      "created_at": "2022-02-18T14:03:59.954Z",
+                      "updated_at": "2022-11-21T13:49:54.949Z",
+                      "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
+                      "redemption": {
+                        "quantity": null,
+                        "redeemed_quantity": 1,
+                        "redeemed_points": 300,
+                        "object": "list",
+                        "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
+                      },
+                      "publish": {
+                        "object": "list",
+                        "count": 1,
+                        "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
+                      },
+                      "object": "voucher"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "description": "Retrieve loyalty card with the given member ID (i.e. voucher code).    \n\n<!-- theme: info -->\n> #### Read more\n> This endpoint is an alternative to this <!-- [endpoint](OpenAPI.json/paths/~1loyalties~1{campaignId}~1members~1{memberId}/post) -->[endpoint](ref:get-member). The URL was re-designed to allow you to retrieve loyalty card details without having to provide the `campaignId` as a path parameter.",
+        "tags": [
+          "LOYALTIES API"
         ]
       }
     },
-    "/loyalties/{campaignId}/members/{memberId}/redemption": {
+    "/loyalties/{campaignId}/members/{memberId}/activities": {
       "parameters": [
         {
           "schema": {
@@ -53698,22 +53223,164 @@
           "description": "A code that identifies the loyalty card."
         }
       ],
-      "post": {
-        "summary": "Redeem Reward",
-        "operationId": "post-loyalties-campaignId-members-memberId-redemption",
+      "get": {
+        "summary": "Get Member Activities",
+        "operationId": "get-loyalties-campaignId-members-memberId-activities",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_redeem_reward"
+                  "$ref": "#/components/schemas/8_res_get_member_activities"
                 }
               }
             }
           }
         },
-        "description": "Exchange points from a loyalty card for a specified reward. This API method returns an assigned award in the response. It means that if a requesting customer gets a coupon code with a discount for the next order, that discount code will be visible in response as part of the reward object definition.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "description": "Retrieves the list of activities for the given member ID related to voucher and customer who is a holder of the voucher.",
+        "tags": [
+          "LOYALTIES API"
+        ]
+      }
+    },
+    "/loyalties/members/{memberId}/activities": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "MmFAzfDe"
+          },
+          "name": "memberId",
+          "in": "path",
+          "required": true,
+          "description": "Unique loyalty card assigned to a particular customer."
+        }
+      ],
+      "get": {
+        "summary": "Get Member Activities",
+        "operationId": "get-loyalties-members-memberId-activities",
+        "responses": {
+          "200": {
+            "description": "Returns a list of event objects related to the loyalty card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_res_get_member_activities"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "description": "Retrieves a list of activities for the given loyalty card related to the loyalty and customer who is the holder of the loyalty card.",
+        "tags": [
+          "LOYALTIES API"
+        ]
+      }
+    },
+    "/loyalties/{campaignId}/members/{memberId}/balance": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "Unique campaign ID."
+        },
+        {
+          "schema": {
+            "type": "string",
+            "example": "MmFAzfDe"
+          },
+          "name": "memberId",
+          "in": "path",
+          "required": true,
+          "description": "A code that identifies the loyalty card."
+        }
+      ],
+      "post": {
+        "summary": "Add or Remove Loyalty Card Balance",
+        "operationId": "post-loyalties-campaignId-members-memberId-balance",
+        "responses": {
+          "200": {
+            "description": "Returns a balance object.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_res_add_remove_points_balance"
+                },
+                "examples": {
+                  "Add balance": {
+                    "value": {
+                      "points": -100,
+                      "total": 13436,
+                      "balance": 13136,
+                      "type": "loyalty_card",
+                      "object": "balance",
+                      "related_object": {
+                        "type": "voucher",
+                        "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF"
+                      }
+                    }
+                  },
+                  "Deduct balance": {
+                    "value": {
+                      "points": -100,
+                      "total": 13436,
+                      "balance": 13136,
+                      "type": "loyalty_card",
+                      "object": "balance",
+                      "related_object": {
+                        "type": "voucher",
+                        "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Returns an error if the expiration date was defined incorrectly in the request payload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/e_error_no_translation"
+                },
+                "examples": {
+                  "Invalid expiration date": {
+                    "value": {
+                      "code": 400,
+                      "key": "invalid_expiration_date",
+                      "message": "Invalid Expiration Date",
+                      "details": "Expiration date cannot be set in the past",
+                      "request_id": "v-0c118b1611424ca899"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -53726,18 +53393,33 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/8_req_redeem_reward"
+                "$ref": "#/components/schemas/8_req_add_remove_points_balance"
+              },
+              "examples": {
+                "Add points": {
+                  "value": {
+                    "points": 100,
+                    "expiration_type": "CUSTOM_DATE",
+                    "expiration_date": "2023-05-30"
+                  }
+                },
+                "Deduct points": {
+                  "value": {
+                    "points": -100
+                  }
+                }
               }
             }
           },
-          "description": "Specify the reward to be redeemed."
+          "description": "Specify the point adjustment along with the expiration mechanism."
         },
+        "description": "This method adds or removes balance to an existing loyalty card. The removal of points will consume the points that expire the soonest.",
         "tags": [
           "LOYALTIES API"
         ]
       }
     },
-    "/loyalties/members/{memberId}/redemption": {
+    "/loyalties/members/{memberId}/balance": {
       "parameters": [
         {
           "schema": {
@@ -53751,35 +53433,51 @@
         }
       ],
       "post": {
-        "summary": "Redeem Reward",
-        "operationId": "post-loyalties-members-memberId-redemption",
+        "summary": "Add or Remove Loyalty Card Balance",
+        "operationId": "post-loyalties-members-memberId-balance",
         "responses": {
           "200": {
-            "description": "",
+            "description": "Returns a balance object.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_redeem_reward"
+                  "$ref": "#/components/schemas/8_res_add_remove_points_balance"
+                },
+                "examples": {
+                  "Subtract Points": {
+                    "value": {
+                      "points": 100,
+                      "total": 13436,
+                      "balance": 13136,
+                      "type": "loyalty_card",
+                      "object": "balance",
+                      "related_object": {
+                        "type": "voucher",
+                        "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF"
+                      }
+                    }
+                  }
                 }
               }
             }
           },
           "400": {
-            "description": "Returns an error indicating that a reward is missing.",
+            "description": "Returns an error if the expiration date was specified incorrectly in the request payload.",
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/e_400_missing_reward"
-                    },
-                    {
-                      "$ref": "#/components/schemas/e_400_missing_order"
-                    },
-                    {
-                      "$ref": "#/components/schemas/e_400_loyalty_card_points_exceeded"
+                  "$ref": "#/components/schemas/e_error_no_translation"
+                },
+                "examples": {
+                  "Invalid payload": {
+                    "value": {
+                      "code": 400,
+                      "key": "invalid_payload",
+                      "message": "Invalid payload",
+                      "details": "Property .expiration_date cannot be recognized as a ISO-8601 compliant date",
+                      "request_id": "v-0c118c6f7c0e6751ab"
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -53796,15 +53494,446 @@
             "$ref": "#/components/parameters/X-App-Token"
           }
         ],
+        "description": "This method gives adds or removes balance to an existing loyalty card. The removal of points will consume the points that expire the soonest.",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/8_req_redeem_reward"
+                "$ref": "#/components/schemas/8_req_add_remove_points_balance"
+              },
+              "examples": {
+                "Subtract points": {
+                  "value": {
+                    "points": -100
+                  }
+                },
+                "Add Points": {
+                  "value": {
+                    "points": 100,
+                    "expiration_type": "CUSTOM_DATE",
+                    "expiration_date": "2023-05-30"
+                  }
+                }
               }
             }
           },
-          "description": "Specify the reward to be redeemed."
+          "description": "Specify the point adjustment along with the expiration mechanism."
+        }
+      }
+    },
+    "/loyalties/{campaignId}/members/{memberId}/transfers": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "A unique identifier of the loyalty campaign containing the voucher to which the loyalty points will be sent (destination)."
+        },
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "memberId",
+          "in": "path",
+          "required": true,
+          "description": "A unique code identifying the loyalty card to which the user wants to transfer loyalty points (destination)."
+        }
+      ],
+      "post": {
+        "summary": "Transfer Loyalty Points",
+        "operationId": "post-loyalties-campaignId-members-memberId-transfers",
+        "responses": {
+          "200": {
+            "description": "Returns a loyalty card object for the loaded loyalty card, ie. the one that that points were transferred to from the other cards(s).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_obj_loyalty_card_object_non_expanded_categories"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                      "code": "MmFAzfDe",
+                      "campaign": "Proportional Earning Rules",
+                      "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                      "category": null,
+                      "category_id": "cat_0b6152ce12414820de",
+                      "categories": [],
+                      "type": "LOYALTY_CARD",
+                      "discount": null,
+                      "gift": null,
+                      "loyalty_card": {
+                        "points": 13441,
+                        "balance": 13141,
+                        "next_expiration_date": "2022-11-30",
+                        "next_expiration_points": 0
+                      },
+                      "start_date": null,
+                      "expiration_date": null,
+                      "validity_timeframe": null,
+                      "validity_day_of_week": null,
+                      "active": true,
+                      "additional_info": null,
+                      "metadata": {},
+                      "assets": {
+                        "qr": {
+                          "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
+                        },
+                        "barcode": {
+                          "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
+                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
+                        }
+                      },
+                      "is_referral_code": false,
+                      "created_at": "2022-02-18T14:03:59.954Z",
+                      "updated_at": "2022-11-28T17:58:25.607Z",
+                      "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
+                      "redemption": {
+                        "quantity": null,
+                        "redeemed_quantity": 1,
+                        "redeemed_points": 300,
+                        "object": "list",
+                        "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
+                      },
+                      "publish": {
+                        "object": "list",
+                        "count": 1,
+                        "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
+                      },
+                      "object": "voucher"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Transfer points between different loyalty cards. You need to provide the campaign ID and the loyalty card ID you want the points to be transferred to as path parameters in the URL. In the request body, you provide the loyalty cards you want the points to be transferred from and the number of points to transfer from each card.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_transfer_loyalty_points"
+              },
+              "examples": {
+                "Example": {
+                  "value": [
+                    {
+                      "code": "0PmQ7JQI",
+                      "points": 1
+                    },
+                    {
+                      "code": "kCeufB8i",
+                      "points": 1
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "description": "Provide the loyalty cards you want the points to be transferred from and the number of points to transfer from each card."
+        },
+        "tags": [
+          "LOYALTIES API"
+        ]
+      }
+    },
+    "/loyalties/{campaignId}/members/{memberId}/points-expiration": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+        },
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "memberId",
+          "in": "path",
+          "required": true,
+          "description": "Loyalty card code."
+        }
+      ],
+      "get": {
+        "summary": "Get Points Expiration",
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of loyalty points expiration buckets along with an expiration date if the points are due to expire. No expiration date parameter is returned if the loyalty points bucket does not expire.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_res_get_points_expiration"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "object": "list",
+                      "data_ref": "data",
+                      "data": [
+                        {
+                          "id": "lopb_ERSwDxeWTlvWwFrn3AtJxt3s",
+                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "bucket": {
+                            "total_points": 2
+                          },
+                          "status": "ACTIVE",
+                          "expires_at": "2022-11-25",
+                          "created_at": "2022-11-25T09:10:20.994Z",
+                          "object": "loyalty_points_bucket"
+                        },
+                        {
+                          "id": "lopb_zdeIBq3EsnPnRSDa7Tyyb6X2",
+                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "bucket": {
+                            "total_points": 12
+                          },
+                          "status": "ACTIVE",
+                          "expires_at": "2022-11-30",
+                          "created_at": "2022-11-21T13:49:54.949Z",
+                          "object": "loyalty_points_bucket"
+                        },
+                        {
+                          "id": "lopb_Mg80vhZtqHFItWlJFYZ2rJAS",
+                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "bucket": {
+                            "total_points": 0
+                          },
+                          "status": "ACTIVE",
+                          "expires_at": "2023-05-30",
+                          "created_at": "2022-06-09T11:07:07.344Z",
+                          "updated_at": "2022-08-30T08:34:45.989Z",
+                          "object": "loyalty_points_bucket"
+                        },
+                        {
+                          "id": "lopb_dQE1TwyTkHAJDlVCPlqSC0nu",
+                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "bucket": {
+                            "total_points": 13124
+                          },
+                          "status": "ACTIVE",
+                          "created_at": "2022-02-28T12:13:57.749Z",
+                          "updated_at": "2022-11-25T09:09:51.136Z",
+                          "object": "loyalty_points_bucket"
+                        }
+                      ],
+                      "total": 4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-loyalties-campaignId-members-memberId-points-expiration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          },
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
+        "description": "Retrieve loyalty point expiration buckets for a given loyalty card."
+      }
+    },
+    "/loyalties/{campaignId}/points-expiration/export": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "Unique campaign ID or name."
+        }
+      ],
+      "post": {
+        "summary": "Create Points Expiration Export",
+        "operationId": "post-loyalties-campaignId-points-expiration-export",
+        "responses": {
+          "200": {
+            "description": "Returns an object with the export ID of the scheduled generation of CSV file with exported points expirations. You can use either the <!-- [Get Export](OpenAPI.json/paths/~1exports~1{exportId}/get) -->[Get Export](ref:get-export) endpoint to view the status and obtain the URL of the CSV file or <!-- [Download Export](OpenAPI.json/paths/~1exports~1{export_Id}/get) -->[Download Export](ref:download-export) endpoint to download the CSV file.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_obj_export_object_points_expiration"
+                },
+                "examples": {
+                  "Specific Vouchers": {
+                    "value": {
+                      "id": "exp_zC3eXAFss17XTMzMkkov4KGq",
+                      "object": "export",
+                      "created_at": "2022-11-28T13:00:23.621Z",
+                      "status": "SCHEDULED",
+                      "channel": "API",
+                      "exported_object": "points_expiration",
+                      "parameters": {
+                        "order": "-expires_at",
+                        "fields": [
+                          "id",
+                          "campaign_id",
+                          "voucher_id",
+                          "status",
+                          "expires_at",
+                          "points"
+                        ],
+                        "filters": {
+                          "junction": "and",
+                          "voucher_id": {
+                            "conditions": {
+                              "$in": [
+                                "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                                "v_YLn0WVWXSXbUfDvxgrgUbtfJ3SQIY655"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "result": null,
+                      "user_id": null
+                    }
+                  },
+                  "Specific Campaign": {
+                    "value": {
+                      "id": "exp_kfwVDMsavDHl2vOY6vH9q7P7",
+                      "object": "export",
+                      "created_at": "2022-11-28T16:46:34.148Z",
+                      "status": "SCHEDULED",
+                      "channel": "API",
+                      "exported_object": "points_expiration",
+                      "parameters": {
+                        "order": "-expires_at",
+                        "fields": [
+                          "id",
+                          "campaign_id",
+                          "voucher_id",
+                          "status",
+                          "expires_at",
+                          "points"
+                        ],
+                        "filters": {
+                          "junction": "and",
+                          "campaign_id": {
+                            "conditions": {
+                              "$is": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
+                            }
+                          }
+                        }
+                      },
+                      "result": null,
+                      "user_id": null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "description": "Schedule the generation of a points expiration CSV file for a particular campaign.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_export_points_expirations"
+              },
+              "examples": {
+                "Specific Vouchers": {
+                  "value": {
+                    "parameters": {
+                      "fields": [
+                        "id",
+                        "campaign_id",
+                        "voucher_id",
+                        "status",
+                        "expires_at",
+                        "points"
+                      ],
+                      "order": "-expires_at",
+                      "filters": {
+                        "junction": "and",
+                        "voucher_id": {
+                          "conditions": {
+                            "$in": [
+                              "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
+                              "v_YLn0WVWXSXbUfDvxgrgUbtfJ3SQIY655"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "Specific campaign": {
+                  "value": {
+                    "parameters": {
+                      "fields": [
+                        "id",
+                        "campaign_id",
+                        "voucher_id",
+                        "status",
+                        "expires_at",
+                        "points"
+                      ],
+                      "order": "-expires_at",
+                      "filters": {
+                        "junction": "and",
+                        "campaign_id": {
+                          "conditions": {
+                            "$is": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "description": "Specify the data filters, types of data to return and order in which the results should be returned."
         }
       }
     },
@@ -56274,141 +56403,217 @@
         "description": "Disable an earning rule."
       }
     },
-    "/loyalties/{campaignId}/members": {
+    "/loyalties/members/{memberId}/rewards": {
       "parameters": [
         {
           "schema": {
-            "type": "string"
+            "type": "string",
+            "example": "MmFAzfDe"
           },
-          "name": "campaignId",
+          "name": "memberId",
           "in": "path",
           "required": true,
-          "description": "Unique campaign ID of the loyalty program from which you want to assign a loyalty card."
+          "description": "Unique loyalty card assigned to a particular customer."
         }
       ],
       "get": {
-        "summary": "List Members",
-        "tags": [
-          "LOYALTIES API"
-        ],
+        "summary": "List Member Rewards",
+        "operationId": "get-loyalties-members-memberId-rewards",
         "responses": {
           "200": {
-            "description": "Returns a list of loyalty cards within a campaign.",
+            "description": "Returns a list of rewards for the given `member_id`. Returns a filtered list if the query parameter `affordable_only` is set to `true`.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_list_members"
+                  "$ref": "#/components/schemas/8_res_list_member_rewards"
                 },
                 "examples": {
                   "Example": {
                     "value": {
                       "object": "list",
-                      "data_ref": "vouchers",
-                      "vouchers": [
+                      "data_ref": "data",
+                      "data": [
                         {
-                          "id": "v_YLn0WVWXSXbUfDvxgrgUbtfJ3SQIY655",
-                          "code": "0PmQ7JQI",
-                          "campaign": "Loyalty Campaign",
-                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "category": null,
-                          "category_id": null,
-                          "categories": [],
-                          "type": "LOYALTY_CARD",
-                          "discount": null,
-                          "gift": null,
-                          "loyalty_card": {
-                            "points": 0,
-                            "balance": 0
-                          },
-                          "start_date": null,
-                          "expiration_date": null,
-                          "validity_timeframe": null,
-                          "validity_day_of_week": null,
-                          "active": true,
-                          "additional_info": null,
-                          "metadata": {},
-                          "assets": {
-                            "qr": {
-                              "id": "U2FsdGVkX19RtPewWeUYb2hiCR6xEhVE3SLdMfCXj3BA/s6uqSwFl2oAKAt9K5dolsdcZcj5Jgaa/YCnKkm63TRuX6OgGJoEggbKMg+wLfCMwBSi4J2v8KXuyqM25wP4r9WAL58Z+z3B1jkALIbjtw==",
-                              "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX19RtPewWeUYb2hiCR6xEhVE3SLdMfCXj3BA%2Fs6uqSwFl2oAKAt9K5dolsdcZcj5Jgaa%2FYCnKkm63TRuX6OgGJoEggbKMg%2BwLfCMwBSi4J2v8KXuyqM25wP4r9WAL58Z%2Bz3B1jkALIbjtw%3D%3D"
+                          "reward": {
+                            "id": "rew_C7wS9eHFDN4CIbXI5PpLSkGY",
+                            "name": "Material Reward",
+                            "type": "MATERIAL",
+                            "parameters": {
+                              "product": {
+                                "id": "prod_0b7d7dfb05cbe5c616",
+                                "sku_id": "sku_0b7d7dfb090be5c619"
+                              }
                             },
-                            "barcode": {
-                              "id": "U2FsdGVkX1+hrRfaPMHRRX5aGVz2RpurRBjC2brcHcptPs4Od93qZM51vUXZe4DDzfRbnVrP+BfBtF+pyyQpxCeqbQuB/OuSnP/nzec6n0n/gTb9+XcIYLvvxcbnDbYoVdRFQEbcCxKKo4QzDlqIjQ==",
-                              "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2BhrRfaPMHRRX5aGVz2RpurRBjC2brcHcptPs4Od93qZM51vUXZe4DDzfRbnVrP%2BBfBtF%2BpyyQpxCeqbQuB%2FOuSnP%2Fnzec6n0n%2FgTb9%2BXcIYLvvxcbnDbYoVdRFQEbcCxKKo4QzDlqIjQ%3D%3D"
-                            }
+                            "stock": 4,
+                            "redeemed": 1,
+                            "attributes": {
+                              "description": "Get a Comic Book in Archie's series."
+                            },
+                            "created_at": "2022-08-17T07:46:18.619169+00:00",
+                            "updated_at": "2022-08-17T08:13:48.30747+00:00",
+                            "metadata": {},
+                            "object": "reward"
                           },
-                          "is_referral_code": false,
-                          "created_at": "2022-04-15T05:48:45.509Z",
-                          "updated_at": "2022-07-01T00:01:57.860Z",
-                          "holder_id": "cust_nk0N1uNQ1YnupAoJGOgvsODC",
-                          "redemption": {
-                            "quantity": null,
-                            "redeemed_quantity": 0,
-                            "redeemed_points": 0,
-                            "object": "list",
-                            "url": "/v1/vouchers/0PmQ7JQI/redemptions?page=1&limit=10"
+                          "assignment": {
+                            "id": "rewa_pJYQBXSitK2OVPK3XMXZK76X",
+                            "reward_id": "rew_C7wS9eHFDN4CIbXI5PpLSkGY",
+                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
+                            "related_object_type": "campaign",
+                            "parameters": {
+                              "loyalty": {
+                                "points": 39
+                              }
+                            },
+                            "created_at": "2022-08-24T11:40:22.418972+00:00",
+                            "updated_at": "2022-08-24T13:23:50.409121+00:00",
+                            "object": "reward_assignment"
                           },
-                          "publish": {
-                            "object": "list",
-                            "count": 1,
-                            "url": "/v1/vouchers/0PmQ7JQI/publications?page=1&limit=10"
-                          },
-                          "object": "voucher"
+                          "object": "loyalty_reward"
                         },
                         {
-                          "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                          "code": "MmFAzfDe",
-                          "campaign": "Loyalty Campaign",
-                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "category": null,
-                          "category_id": "cat_0b6152ce12414820de",
-                          "categories": [],
-                          "type": "LOYALTY_CARD",
-                          "discount": null,
-                          "gift": null,
-                          "loyalty_card": {
-                            "points": 13435,
-                            "balance": 13135,
-                            "next_expiration_date": "2022-11-30",
-                            "next_expiration_points": 12
-                          },
-                          "start_date": null,
-                          "expiration_date": null,
-                          "validity_timeframe": null,
-                          "validity_day_of_week": null,
-                          "active": true,
-                          "additional_info": null,
-                          "metadata": {},
-                          "assets": {
-                            "qr": {
-                              "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
-                              "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
+                          "reward": {
+                            "id": "rew_31M6Za6zkMRfhxYJz4aDo11h",
+                            "name": "Pay with Points",
+                            "type": "COIN",
+                            "parameters": {
+                              "coin": {
+                                "exchange_ratio": 1,
+                                "points_ratio": 1
+                              }
                             },
-                            "barcode": {
-                              "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
-                              "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
-                            }
+                            "stock": null,
+                            "redeemed": null,
+                            "attributes": {},
+                            "created_at": "2022-06-23T11:06:06.222736+00:00",
+                            "updated_at": null,
+                            "metadata": null,
+                            "object": "reward"
                           },
-                          "is_referral_code": false,
-                          "created_at": "2022-02-18T14:03:59.954Z",
-                          "updated_at": "2022-11-21T13:49:54.949Z",
-                          "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
-                          "redemption": {
-                            "quantity": null,
-                            "redeemed_quantity": 1,
-                            "redeemed_points": 300,
-                            "object": "list",
-                            "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
+                          "assignment": {
+                            "id": "rewa_wrVYAfXWolq52gnl15dumPCq",
+                            "reward_id": "rew_31M6Za6zkMRfhxYJz4aDo11h",
+                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
+                            "related_object_type": "campaign",
+                            "created_at": "2022-08-11T14:13:34.581194+00:00",
+                            "updated_at": null,
+                            "object": "reward_assignment"
                           },
-                          "publish": {
-                            "object": "list",
-                            "count": 1,
-                            "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
+                          "object": "loyalty_reward"
+                        },
+                        {
+                          "reward": {
+                            "id": "rew_Jhq0ecLGSx8eF4pFdlhFr9P6",
+                            "name": "20% discount",
+                            "type": "CAMPAIGN",
+                            "parameters": {
+                              "campaign": {
+                                "id": "camp_4B1jDE63pCeSij3HU7gx3gPT",
+                                "type": "DISCOUNT_COUPONS"
+                              }
+                            },
+                            "stock": null,
+                            "redeemed": null,
+                            "attributes": {},
+                            "created_at": "2022-08-11T09:52:39.032699+00:00",
+                            "updated_at": null,
+                            "metadata": {},
+                            "object": "reward"
                           },
-                          "object": "voucher"
+                          "assignment": {
+                            "id": "rewa_nFREw86qh1LiqGPRygahNh8Z",
+                            "reward_id": "rew_Jhq0ecLGSx8eF4pFdlhFr9P6",
+                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
+                            "related_object_type": "campaign",
+                            "parameters": {
+                              "loyalty": {
+                                "points": 100
+                              }
+                            },
+                            "created_at": "2022-08-11T14:13:34.581194+00:00",
+                            "updated_at": null,
+                            "object": "reward_assignment"
+                          },
+                          "object": "loyalty_reward"
+                        },
+                        {
+                          "reward": {
+                            "id": "rew_Dev2yQLodRV33UKPKHTUQWk1",
+                            "name": "Get a product",
+                            "type": "MATERIAL",
+                            "parameters": {
+                              "product": {
+                                "id": "prod_0b2ac1dab28985cb1e",
+                                "sku_id": null
+                              }
+                            },
+                            "stock": 1,
+                            "redeemed": 1,
+                            "attributes": {
+                              "description": "Product"
+                            },
+                            "created_at": "2022-06-13T10:43:15.929621+00:00",
+                            "updated_at": "2022-08-11T15:59:30.820937+00:00",
+                            "metadata": null,
+                            "object": "reward"
+                          },
+                          "assignment": {
+                            "id": "rewa_SV4gMgPXTXDrsoTyqhY1B2ut",
+                            "reward_id": "rew_Dev2yQLodRV33UKPKHTUQWk1",
+                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
+                            "related_object_type": "campaign",
+                            "parameters": {
+                              "loyalty": {
+                                "points": 4000
+                              }
+                            },
+                            "created_at": "2022-08-11T14:13:34.581194+00:00",
+                            "updated_at": null,
+                            "object": "reward_assignment"
+                          },
+                          "object": "loyalty_reward"
+                        },
+                        {
+                          "reward": {
+                            "id": "rew_oQEYtUNYcVe2IdBEUBdLfkCD",
+                            "name": "Get a comic book",
+                            "type": "MATERIAL",
+                            "parameters": {
+                              "product": {
+                                "id": "prod_0b7d7dfb05cbe5c616",
+                                "sku_id": null
+                              }
+                            },
+                            "stock": 1,
+                            "redeemed": 2,
+                            "attributes": {
+                              "image_url": "https://voucherify-uploads.s3.amazonaws.com/org_2qt8DYlM/img_fPH9ohe0pZf4EiIt295sk9Ob.png",
+                              "description": "Archie's Series"
+                            },
+                            "created_at": "2022-08-11T14:35:44.694611+00:00",
+                            "updated_at": "2022-08-17T07:52:56.965366+00:00",
+                            "metadata": {
+                              "Type": "GR-2"
+                            },
+                            "object": "reward"
+                          },
+                          "assignment": {
+                            "id": "rewa_7HHH6TjN7Q9WDr5ZePeZUg5p",
+                            "reward_id": "rew_oQEYtUNYcVe2IdBEUBdLfkCD",
+                            "related_object_id": "camp_jcErmtGAOmHUAy0oUgkwKnPZ",
+                            "related_object_type": "campaign",
+                            "parameters": {
+                              "loyalty": {
+                                "points": 10
+                              }
+                            },
+                            "created_at": "2022-08-11T15:44:12.789086+00:00",
+                            "updated_at": null,
+                            "object": "reward_assignment"
+                          },
+                          "object": "loyalty_reward"
                         }
                       ],
-                      "total": 2
+                      "total": 5
                     }
                   }
                 }
@@ -56416,7 +56621,164 @@
             }
           }
         },
-        "operationId": "get-loyalties-campaignId-members",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          },
+          {
+            "in": "query",
+            "name": "affordable_only",
+            "description": "Limit the results to rewards that the customer can actually afford (only rewards whose price in points is not higher than the loyalty points balance on a loyalty card). Set this flag to `true` to return rewards which the customer can actually afford.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "description": "Retrieves the list of rewards that the given customer (identified by `member_id`, which is a loyalty card assigned to a particular customer) **can get in exchange for loyalty points**.  \n\nYou can use the `affordable_only` parameter to limit the results to rewards that the customer can actually afford (only rewards whose price in points is not higher than the loyalty points balance on a loyalty card).  \n\nPlease note that rewards that are disabled (i.e. set to `Not Available` in the Dashboard) for a given loyalty tier reward mapping will not be returned in this endpoint.",
+        "tags": [
+          "LOYALTIES API"
+        ]
+      }
+    },
+    "/loyalties/{campaignId}/reward-assignments/{assignmentId}/reward": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "camp_pqZjuhG6Mgtp4GD0zD7b8hA3"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+        },
+        {
+          "schema": {
+            "type": "string",
+            "example": "rewa_hzc19a5NLyIr2bVL3UB1w0B3"
+          },
+          "name": "assignmentId",
+          "in": "path",
+          "required": true,
+          "description": "Unique reward assignment ID."
+        }
+      ],
+      "get": {
+        "summary": "Get Reward Details",
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns reward details in the context of a loyalty *campaign* and reward assignment ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4_obj_reward_object"
+                },
+                "examples": {
+                  "Material": {
+                    "value": {
+                      "id": "rew_Dev2yQLodRV33UKPKHTUQWk1",
+                      "name": "Get a product",
+                      "type": "MATERIAL",
+                      "parameters": {
+                        "product": {
+                          "id": "prod_0b2ac1dab28985cb1e",
+                          "sku_id": null
+                        }
+                      },
+                      "stock": "1",
+                      "redeemed": "1",
+                      "attributes": {
+                        "description": "Product"
+                      },
+                      "created_at": "2022-06-13T10:43:15.929Z",
+                      "updated_at": "2022-08-11T15:59:30.820Z",
+                      "metadata": null,
+                      "object": "reward"
+                    }
+                  },
+                  "Pay with Points": {
+                    "value": {
+                      "id": "rew_31M6Za6zkMRfhxYJz4aDo11h",
+                      "name": "Pay with Points",
+                      "type": "COIN",
+                      "parameters": {
+                        "coin": {
+                          "exchange_ratio": 1,
+                          "points_ratio": 1
+                        }
+                      },
+                      "stock": null,
+                      "redeemed": null,
+                      "attributes": {},
+                      "created_at": "2022-06-23T11:06:06.222Z",
+                      "updated_at": null,
+                      "metadata": null,
+                      "object": "reward"
+                    }
+                  },
+                  "Discount Coupon": {
+                    "value": {
+                      "id": "rew_Jhq0ecLGSx8eF4pFdlhFr9P6",
+                      "name": "20% discount",
+                      "type": "CAMPAIGN",
+                      "parameters": {
+                        "campaign": {
+                          "id": "camp_4B1jDE63pCeSij3HU7gx3gPT",
+                          "type": "DISCOUNT_COUPONS"
+                        }
+                      },
+                      "stock": null,
+                      "redeemed": null,
+                      "attributes": {},
+                      "created_at": "2022-08-11T09:52:39.032Z",
+                      "updated_at": null,
+                      "metadata": {},
+                      "object": "reward"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-loyalties-campaignId-reward-assignments-assignmentId-reward",
+        "description": "Get reward details in the context of a loyalty campaign and reward assignment ID.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ]
+      }
+    },
+    "/loyalties/{campaignId}/reward-assignments": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "camp_pqZjuhG6Mgtp4GD0zD7b8hA3"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+        }
+      ],
+      "get": {
+        "summary": "List Reward Assignments",
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "operationId": "get-loyalties-campaignId-reward-assignments",
+        "description": "Returns reward assignments from a given loyalty campaign.",
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -56431,130 +56793,632 @@
             "$ref": "#/components/parameters/page"
           },
           {
-            "$ref": "#/components/parameters/created_at"
+            "schema": {
+              "type": "string",
+              "example": "rewa_m9hEAu10KsPcLhGXiHG85aY0"
+            },
+            "in": "query",
+            "name": "assignmentId",
+            "description": "A unique reward assignment ID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a dictionary with reward assignment objects.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_res_list_reward_assignments"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "object": "list",
+                      "data_ref": "data",
+                      "data": [
+                        {
+                          "id": "rewa_2EPffrq151ArmjR7j3CumxGE",
+                          "reward_id": "rew_6uCtsIjgcuzi4NW43mKZQWd5",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 18
+                            }
+                          },
+                          "created_at": "2022-06-22T11:02:19.564Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_75e6oBjYfIKUDbM4Dsgg6xAU",
+                          "reward_id": "rew_gI4GYbXMeHAJUAIiZCad5LaS",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 25
+                            }
+                          },
+                          "created_at": "2022-06-22T11:00:49.034Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_dJ5nFBpmL8DVhmY1j4zYYOqF",
+                          "reward_id": "rew_VSi5rNvb67bn2tqkNwVBBP7u",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 100
+                            }
+                          },
+                          "created_at": "2022-06-22T10:57:24.051Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_874iVl5bHrZFr2FSsG9ilKzF",
+                          "reward_id": "rew_QQ73sIywuMoEj6L8K6ft2Mn7",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "created_at": "2022-06-22T10:47:55.934Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_GgSlEk4bnR09lMMts6CgR6aV",
+                          "reward_id": "rew_URQeO2fgbjxHnulgYVguuidX",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 9
+                            }
+                          },
+                          "created_at": "2022-06-22T10:21:53.109Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_i6VcsXr3ovJ2JCpZk9k1JOj1",
+                          "reward_id": "rew_YNr7tRr9TPAiFEJBZBAsuKCq",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "created_at": "2022-06-22T10:18:27.684Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_YjTw2InYSVx1nA88brDASS9e",
+                          "reward_id": "rew_BUfchmIo7pOR8GrZMw0vVL08",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 30
+                            }
+                          },
+                          "created_at": "2022-06-22T09:58:12.133Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
+                          "reward_id": "rew_injbwG52POgfpSogTlQl4hA6",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 10
+                            }
+                          },
+                          "created_at": "2022-06-13T11:56:49.185Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_gb6U5byuRh12EvdiL46P4Cxy",
+                          "reward_id": "rew_NQB7WbdQLBrFQW1DZmBNcLvH",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 100
+                            }
+                          },
+                          "created_at": "2022-06-13T11:50:23.429Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_hfyF9IGez9i3z5a3Uwlkcg7S",
+                          "reward_id": "rew_87ItIc9P5Bky10eS7vEm7Dc7",
+                          "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 20
+                            }
+                          },
+                          "created_at": "2022-06-13T11:20:43.961Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        }
+                      ],
+                      "total": 12
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/loyalties/{campaignId}/rewards": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "Unique campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+        }
+      ],
+      "get": {
+        "summary": "List Reward Assignments",
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a dictionary with reward assignment objects.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/8_res_list_reward_assignments"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "object": "list",
+                      "data_ref": "data",
+                      "data": [
+                        {
+                          "id": "rewa_6VSWcXjfm5PuZlfeuZxl5JZT",
+                          "reward_id": "rew_pjJKIZgjIopIPZyibEAt7oPk",
+                          "related_object_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "related_object_type": "campaign",
+                          "created_at": "2022-08-30T08:24:32.171Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_7gFZsNg8oiry63FtzML0N52R",
+                          "reward_id": "rew_BUfchmIo7pOR8GrZMw0vVL08",
+                          "related_object_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 3000000
+                            }
+                          },
+                          "created_at": "2022-05-13T11:14:58.146Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        },
+                        {
+                          "id": "rewa_eAGhQSY4FS4T3q4zMkiarHoN",
+                          "reward_id": "rew_nIy4gHpQHle2c3pNMwuj7G6j",
+                          "related_object_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
+                          "related_object_type": "campaign",
+                          "parameters": {
+                            "loyalty": {
+                              "points": 100
+                            }
+                          },
+                          "created_at": "2022-02-28T11:56:55.241Z",
+                          "updated_at": null,
+                          "object": "reward_assignment"
+                        }
+                      ],
+                      "total": 3
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-loyalties-campaignId-rewards",
+        "description": "Returns active <!-- [rewards](OpenAPI.json/components/schemas/4_obj_reward_object) -->rewards from a given loyalty campaign.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
           },
           {
-            "$ref": "#/components/parameters/updated_at"
+            "$ref": "#/components/parameters/X-App-Token"
+          },
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/page"
           },
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "created_at",
-                "-created_at",
-                "updated_at",
-                "-updated_at"
-              ]
+              "example": "rewa_m9hEAu10KsPcLhGXiHG85aY0"
             },
             "in": "query",
-            "name": "order",
-            "description": "Sorts the results using one of the filtering options, where the dash - preceding a sorting option means sorting in a descending order."
+            "name": "assignment_id",
+            "description": "A unique reward assignment ID."
           }
-        ],
-        "description": "Returns a list of your loyalty cards. The loyalty cards are sorted by creation date, with the most recent loyalty cards appearing first."
+        ]
       },
       "post": {
-        "summary": "Add Member",
-        "operationId": "post-loyalties-campaignId-members",
+        "summary": "Create Reward Assignment",
+        "operationId": "post-loyalties-campaignId-rewards",
         "responses": {
           "200": {
-            "description": "Returns the voucher object that was published to the customer provided in the request payload.",
+            "description": "Returns a list of reward assignment objects.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_obj_loyalty_card_object"
+                  "$ref": "#/components/schemas/8_res_create_reward_assignment"
                 },
                 "examples": {
-                  "Loyalty Card": {
-                    "value": {
-                      "id": "v_0TxKw1bm0oZuS5lwA8526vze1OBMV1OH",
-                      "code": "KpzbHUY5",
-                      "campaign": "Loyalty Campaign",
-                      "campaign_id": "camp_eTIsUtuzkRXQT6rsUQqrS5Gw",
-                      "category": "New Customers",
-                      "category_id": "cat_0b6152ce12414820dc",
-                      "categories": [
-                        {
-                          "id": "cat_0b6152ce12414820dc",
-                          "name": "New Customers",
-                          "hierarchy": 0,
-                          "created_at": "2022-07-14T20:17:07.657Z",
-                          "object": "category"
-                        }
-                      ],
-                      "type": "LOYALTY_CARD",
-                      "discount": null,
-                      "gift": null,
-                      "loyalty_card": {
-                        "points": 0,
-                        "balance": 0
-                      },
-                      "start_date": null,
-                      "expiration_date": null,
-                      "validity_timeframe": null,
-                      "validity_day_of_week": null,
-                      "active": true,
-                      "additional_info": null,
-                      "metadata": {
-                        "Season": "Fall"
-                      },
-                      "assets": {
-                        "qr": {
-                          "id": "U2FsdGVkX1+hdZfzUaz448vIsyf7WpvXiDyqFbyw0+P5wMu12w3B5DyYwA7LCSK+Nr7TA7PKGuHOTGxfBieqrhvJo81HiaIJimDOhk+ecEOisMRmHf6XsNckVlyBHmkpBiXWNm8UDwZnXOAG75Usdw==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX1%2BhdZfzUaz448vIsyf7WpvXiDyqFbyw0%2BP5wMu12w3B5DyYwA7LCSK%2BNr7TA7PKGuHOTGxfBieqrhvJo81HiaIJimDOhk%2BecEOisMRmHf6XsNckVlyBHmkpBiXWNm8UDwZnXOAG75Usdw%3D%3D"
+                  "Example": {
+                    "value": [
+                      {
+                        "id": "rewa_Iw9VopmlLm0topBG17ZH1gp5",
+                        "reward_id": "rew_wg2pvCr5LDhCq4uVQZ9LhuZm",
+                        "related_object_id": "camp_fkZ28pe7DUAEmmabofkxHI8N",
+                        "related_object_type": "campaign",
+                        "parameters": {
+                          "loyalty": {
+                            "points": 2
+                          }
                         },
-                        "barcode": {
-                          "id": "U2FsdGVkX19VRXApVvZ9/ArwBd0wNg7s2KZBXrFvPXZdDQyzGj0HbbEIx5TAoXNR9zaE5kzIj9BElzgK82aOMMVnc1sqvr93xw+YeYMnqGqHRZfM78pYC8560Zc3U6IELtxzaJJ0x2uDUe6Dc9XYeg==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX19VRXApVvZ9%2FArwBd0wNg7s2KZBXrFvPXZdDQyzGj0HbbEIx5TAoXNR9zaE5kzIj9BElzgK82aOMMVnc1sqvr93xw%2BYeYMnqGqHRZfM78pYC8560Zc3U6IELtxzaJJ0x2uDUe6Dc9XYeg%3D%3D"
+                        "created_at": "2022-11-28T18:54:19.747Z",
+                        "updated_at": null,
+                        "object": "reward_assignment"
+                      },
+                      {
+                        "id": "rewa_tAFZ7cHiTwZyOg1QaWHt6yYv",
+                        "reward_id": "rew_z35ffKoH0tCcck8EL56p6SIs",
+                        "related_object_id": "camp_fkZ28pe7DUAEmmabofkxHI8N",
+                        "related_object_type": "campaign",
+                        "parameters": {
+                          "loyalty": {
+                            "points": 2
+                          }
+                        },
+                        "created_at": "2022-11-28T18:54:19.747Z",
+                        "updated_at": null,
+                        "object": "reward_assignment"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Returns an error if there's a reward assignment created for the given reward.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/e_409_duplicate_found"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "code": 409,
+                      "key": "duplicate_found",
+                      "message": "Duplicated resource found",
+                      "details": "Duplicated reward_assignment exists with id rewa_50O40FgyojhUiZAs3vDQbKiC",
+                      "request_id": "v-0c11a10ed2ce676da9",
+                      "resource_id": "rewa_50O40FgyojhUiZAs3vDQbKiC",
+                      "resource_type": "reward_assignment"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_create_reward_assignment"
+              },
+              "examples": {
+                "Example": {
+                  "value": [
+                    {
+                      "reward": "rew_wg2pvCr5LDhCq4uVQZ9LhuZm",
+                      "parameters": {
+                        "loyalty": {
+                          "points": 2
+                        }
+                      }
+                    },
+                    {
+                      "reward": "rew_z35ffKoH0tCcck8EL56p6SIs",
+                      "parameters": {
+                        "loyalty": {
+                          "points": 2
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "description": "Define the cost of the rewards in loyalty points."
+        },
+        "description": "Add <!-- [rewards](OpenAPI.json/components/schemas/4_obj_reward_object) -->rewards to a loyalty campaign."
+      }
+    },
+    "/loyalties/{campaignId}/reward-assignments/{assignmentId}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "camp_pqZjuhG6Mgtp4GD0zD7b8hA3"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+        },
+        {
+          "schema": {
+            "type": "string",
+            "example": "rewa_hzc19a5NLyIr2bVL3UB1w0B3"
+          },
+          "name": "assignmentId",
+          "in": "path",
+          "required": true,
+          "description": "Unique reward assignment ID."
+        }
+      ],
+      "get": {
+        "summary": "Get Reward Assignment",
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns specific reward assignment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4_obj_reward_assignment_object"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
+                      "reward_id": "rew_injbwG52POgfpSogTlQl4hA6",
+                      "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                      "related_object_type": "campaign",
+                      "parameters": {
+                        "loyalty": {
+                          "points": 10
                         }
                       },
-                      "is_referral_code": false,
-                      "created_at": "2022-11-21T15:48:57.860Z",
-                      "updated_at": "2022-11-21T15:49:36.671Z",
-                      "holder_id": "cust_8KQmHxAERpgebYcFhSpZRr37",
-                      "redemption": {
-                        "quantity": null,
-                        "redeemed_quantity": 0,
-                        "redeemed_points": 0,
-                        "object": "list",
-                        "url": "/v1/vouchers/KpzbHUY5/redemptions?page=1&limit=10"
+                      "created_at": "2022-06-13T11:56:49.185Z",
+                      "updated_at": null,
+                      "object": "reward_assignment"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-loyalties-campaignId-reward-assignments-assignmentId",
+        "description": "Retrieve specific reward assignment.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ]
+      }
+    },
+    "/loyalties/{campaignId}/rewards/{assignmentId}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string",
+            "example": "camp_0dJG7cCAjquzcxWmZ634bA0C"
+          },
+          "name": "campaignId",
+          "in": "path",
+          "required": true,
+          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
+        },
+        {
+          "schema": {
+            "type": "string",
+            "example": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH"
+          },
+          "name": "assignmentId",
+          "in": "path",
+          "required": true,
+          "description": "A unique reward assignment ID."
+        }
+      ],
+      "put": {
+        "summary": "Update Reward Assignment",
+        "operationId": "put-loyalties-campaignId-rewards-assignmentId",
+        "responses": {
+          "200": {
+            "description": "Returns a reward assignment with an updated points value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4_obj_reward_assignment_object"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "id": "rewa_Iw9VopmlLm0topBG17ZH1gp5",
+                      "reward_id": "rew_wg2pvCr5LDhCq4uVQZ9LhuZm",
+                      "related_object_id": "camp_fkZ28pe7DUAEmmabofkxHI8N",
+                      "related_object_type": "campaign",
+                      "parameters": {
+                        "loyalty": {
+                          "points": 3
+                        }
                       },
-                      "publish": {
-                        "object": "list",
-                        "count": 1,
-                        "url": "/v1/vouchers/KpzbHUY5/publications?page=1&limit=10"
-                      },
-                      "object": "voucher"
+                      "created_at": "2022-11-28T18:54:19.747Z",
+                      "updated_at": "2022-11-28T19:27:40.604Z",
+                      "object": "reward_assignment"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "description": "Updates rewards parameters, i.e. the points cost for the specific reward.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_update_reward_assignment"
+              },
+              "examples": {
+                "Example": {
+                  "value": {
+                    "parameters": {
+                      "loyalty": {
+                        "points": 3
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "400": {
-            "description": "Returns an error.",
+          "description": "Update the points cost for the reward assignment."
+        }
+      },
+      "delete": {
+        "summary": "Delete Reward Assignment",
+        "operationId": "delete-loyalties-campaignId-rewards-assignmentId",
+        "responses": {
+          "204": {
+            "description": "Returns no content if deletion is successful."
+          },
+          "404": {
+            "description": "Returns an error indicating that the loyalty campaign or reward assignment with given ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/e_error_no_translation"
+                  "$ref": "#/components/schemas/e_404_not_found"
                 },
                 "examples": {
-                  "No Voucher Suitable for Publication": {
+                  "Reward Assignment Not Found": {
                     "value": {
-                      "code": 400,
-                      "key": "no_voucher_suitable_for_publication",
-                      "message": "Couldn't find any voucher suitable for publication",
-                      "details": "Couldn't create new vouchers for publication",
-                      "request_id": "v-0c086598620e6704dd"
+                      "code": 404,
+                      "key": "not_found",
+                      "message": "Resource not found",
+                      "details": "Cannot find reward_assignment with id rewa_0b4hqJpVFssxXXrq56Ddtyo",
+                      "request_id": "v-0ae2b69e0cd0c1364f",
+                      "resource_id": "rewa_0b4hqJpVFssxXXrq56Ddtyo",
+                      "resource_type": "reward_assignment"
                     }
                   },
-                  "Voucher already published": {
+                  "Loyalty Campaign Not Found": {
                     "value": {
-                      "code": 400,
-                      "key": "voucher_already_published",
-                      "message": "Voucher already published",
-                      "details": "Voucher 'v_ZFjKHQD0d56eMkWkrotJaVbiMuXClRuM' has already been published",
-                      "request_id": "v-0c086aaa7dc24ccfe0"
+                      "code": 404,
+                      "key": "not_found",
+                      "message": "Resource not found",
+                      "details": "Cannot find campaign with id Loyalty Summer Campaign",
+                      "request_id": "v-0ae2b71e57d027e263",
+                      "resource_id": "Loyalty Summer Campaign",
+                      "resource_type": "campaign"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "LOYALTIES API"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-App-Id"
+          },
+          {
+            "$ref": "#/components/parameters/X-App-Token"
+          }
+        ],
+        "description": "This method deletes a reward assignment for a particular loyalty campaign."
+      },
+      "get": {
+        "summary": "Get Reward Assignment",
+        "operationId": "get-loyalties-campaignId-rewards-assignmentId",
+        "responses": {
+          "200": {
+            "description": "Returns specific reward assignment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4_obj_reward_assignment_object"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
+                      "reward_id": "rew_injbwG52POgfpSogTlQl4hA6",
+                      "related_object_id": "camp_Vr97XXNOnFEUIMFymKK99FAA",
+                      "related_object_type": "campaign",
+                      "parameters": {
+                        "loyalty": {
+                          "points": 10
+                        }
+                      },
+                      "created_at": "2022-06-13T11:56:49.185Z",
+                      "updated_at": null,
+                      "object": "reward_assignment"
                     }
                   }
                 }
@@ -56562,7 +57426,7 @@
             }
           },
           "404": {
-            "description": "Returns an error if the voucher code that was specified in the request payload is not found.",
+            "description": "Returns an error if the reward assignment cannot be found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -56574,10 +57438,10 @@
                       "code": 404,
                       "key": "not_found",
                       "message": "Resource not found",
-                      "details": "Cannot find voucher with id Loyalty_Card",
-                      "request_id": "v-0c086a26de424ccf2f",
-                      "resource_id": "Loyalty_Card",
-                      "resource_type": "voucher"
+                      "details": "Cannot find reward_assignment with id rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
+                      "request_id": "v-0c0be6ee648e67609b",
+                      "resource_id": "rewa_1gJ6VyYQI0IcnEvhArbr9XFH",
+                      "resource_type": "reward_assignment"
                     }
                   }
                 }
@@ -56588,6 +57452,7 @@
         "tags": [
           "LOYALTIES API"
         ],
+        "description": "Retrieve specific reward assignment.",
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -56595,628 +57460,10 @@
           {
             "$ref": "#/components/parameters/X-App-Token"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_add_member"
-              },
-              "examples": {
-                "Using source ID": {
-                  "value": {
-                    "customer": "source_customer_1",
-                    "metadata": {
-                      "year": 2022
-                    },
-                    "channel": "postman",
-                    "voucher": "KpzbHUY5"
-                  }
-                },
-                "Using unique Voucherify assigned ID": {
-                  "value": {
-                    "customer": "cust_8KQmHxAERpgebYcFhSpZRr37",
-                    "metadata": {
-                      "year": 2022
-                    },
-                    "channel": "postman",
-                    "voucher": "KpzbHUY5"
-                  }
-                },
-                "Using source ID in object": {
-                  "value": {
-                    "customer": {
-                      "source_id": "source_customer_1"
-                    },
-                    "metadata": {
-                      "year": 2022
-                    },
-                    "channel": "postman",
-                    "voucher": "KpzbHUY5"
-                  }
-                },
-                "Using unique Voucherify assigned ID in object": {
-                  "value": {
-                    "customer": {
-                      "id": "cust_8KQmHxAERpgebYcFhSpZRr37"
-                    },
-                    "metadata": {
-                      "year": 2022
-                    },
-                    "channel": "postman",
-                    "voucher": "KpzbHUY5"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Provide details to whom the loyalty card should be assigned.    \n\nYou can choose to either specify the exact loyalty card code that you want to publish from existin (non-assigned) codes, or choose not to specify a voucher code. If you choose not to specify a code in the request paylaod, then the system will choose the next available voucher code available to be assigned to a customer.  \n\nYou can also include metadata in the request payload. This metadata will be assigned to the publication object, but will not be returned in the response to this endpoint. To see of publications (assignments of particular codes to customers) and publication metadata, use the <!-- [List Publications](OpenAPI.json/paths/~1publications/get) -->[List Publications](ref:list-publications) endpoint."
-        },
-        "description": "This method assigns a loyalty card to a customer. It selects a <!-- [loyalty card](OpenAPI.json/components/schemas/1_obj_voucher_object) -->[loyalty card](ref:get-voucher) suitable for publication, adds a publish entry, and returns the published voucher.  \n\nA voucher is suitable for publication when it's active and hasn't been published yet.  \n\n<!-- theme: info -->\n\n> #### Auto-update campaign\n>\n> In case you want to ensure the number of publishable codes increases automatically with the number of customers, you should use **auto-update** campaign.\n\n\n"
-      }
-    },
-    "/loyalties/{campaignId}/members/{memberId}": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "Unique campaign ID."
-        },
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "Unique code that identifies the loyalty card."
-        }
-      ],
-      "get": {
-        "summary": "Get Member",
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns loyalty card details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_obj_loyalty_card_object_non_expanded_categories"
-                },
-                "examples": {
-                  "Loyalty Card": {
-                    "value": {
-                      "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                      "code": "MmFAzfDe",
-                      "campaign": "Loyalty Program",
-                      "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                      "category": null,
-                      "category_id": "cat_0b6152ce12414820de",
-                      "categories": [],
-                      "type": "LOYALTY_CARD",
-                      "discount": null,
-                      "gift": null,
-                      "loyalty_card": {
-                        "points": 13435,
-                        "balance": 13135,
-                        "next_expiration_date": "2022-11-30",
-                        "next_expiration_points": 12
-                      },
-                      "start_date": null,
-                      "expiration_date": null,
-                      "validity_timeframe": null,
-                      "validity_day_of_week": null,
-                      "active": true,
-                      "additional_info": null,
-                      "metadata": {},
-                      "assets": {
-                        "qr": {
-                          "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
-                        },
-                        "barcode": {
-                          "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
-                        }
-                      },
-                      "is_referral_code": false,
-                      "created_at": "2022-02-18T14:03:59.954Z",
-                      "updated_at": "2022-11-21T13:49:54.949Z",
-                      "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
-                      "redemption": {
-                        "quantity": null,
-                        "redeemed_quantity": 1,
-                        "redeemed_points": 300,
-                        "object": "list",
-                        "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
-                      },
-                      "publish": {
-                        "object": "list",
-                        "count": 1,
-                        "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
-                      },
-                      "object": "voucher"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-loyalties-campaignId-members-memberId",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "description": "Retrieves the loyalty card with the given member ID (i.e. voucher code)."
-      }
-    },
-    "/loyalties/members/{memberId}": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "MmFAzfDe"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "Unique loyalty card code assigned to a particular customer."
-        }
-      ],
-      "get": {
-        "summary": "Get Member",
-        "operationId": "get-loyalties-members-memberId",
-        "responses": {
-          "200": {
-            "description": "Returns loyalty card details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_obj_loyalty_card_object_non_expanded_categories"
-                },
-                "examples": {
-                  "Loyalty Card": {
-                    "value": {
-                      "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                      "code": "MmFAzfDe",
-                      "campaign": "Loyalty Program",
-                      "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                      "category": null,
-                      "category_id": "cat_0b6152ce12414820de",
-                      "categories": [],
-                      "type": "LOYALTY_CARD",
-                      "discount": null,
-                      "gift": null,
-                      "loyalty_card": {
-                        "points": 13435,
-                        "balance": 13135,
-                        "next_expiration_date": "2022-11-30",
-                        "next_expiration_points": 12
-                      },
-                      "start_date": null,
-                      "expiration_date": null,
-                      "validity_timeframe": null,
-                      "validity_day_of_week": null,
-                      "active": true,
-                      "additional_info": null,
-                      "metadata": {},
-                      "assets": {
-                        "qr": {
-                          "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
-                        },
-                        "barcode": {
-                          "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
-                        }
-                      },
-                      "is_referral_code": false,
-                      "created_at": "2022-02-18T14:03:59.954Z",
-                      "updated_at": "2022-11-21T13:49:54.949Z",
-                      "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
-                      "redemption": {
-                        "quantity": null,
-                        "redeemed_quantity": 1,
-                        "redeemed_points": 300,
-                        "object": "list",
-                        "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
-                      },
-                      "publish": {
-                        "object": "list",
-                        "count": 1,
-                        "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
-                      },
-                      "object": "voucher"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "description": "Retrieve loyalty card with the given member ID (i.e. voucher code).    \n\n<!-- theme: info -->\n> #### Read more\n> This endpoint is an alternative to this <!-- [endpoint](OpenAPI.json/paths/~1loyalties~1{campaignId}~1members~1{memberId}/post) -->[endpoint](ref:get-member). The URL was re-designed to allow you to retrieve loyalty card details without having to provide the `campaignId` as a path parameter.",
-        "tags": [
-          "LOYALTIES API"
         ]
       }
     },
-    "/loyalties/{campaignId}/members/{memberId}/balance": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "Unique campaign ID."
-        },
-        {
-          "schema": {
-            "type": "string",
-            "example": "MmFAzfDe"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "A code that identifies the loyalty card."
-        }
-      ],
-      "post": {
-        "summary": "Add or Remove Loyalty Card Balance",
-        "operationId": "post-loyalties-campaignId-members-memberId-balance",
-        "responses": {
-          "200": {
-            "description": "Returns a balance object.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_res_add_remove_points_balance"
-                },
-                "examples": {
-                  "Add balance": {
-                    "value": {
-                      "points": -100,
-                      "total": 13436,
-                      "balance": 13136,
-                      "type": "loyalty_card",
-                      "object": "balance",
-                      "related_object": {
-                        "type": "voucher",
-                        "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF"
-                      }
-                    }
-                  },
-                  "Deduct balance": {
-                    "value": {
-                      "points": -100,
-                      "total": 13436,
-                      "balance": 13136,
-                      "type": "loyalty_card",
-                      "object": "balance",
-                      "related_object": {
-                        "type": "voucher",
-                        "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Returns an error if the expiration date was defined incorrectly in the request payload.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/e_error_no_translation"
-                },
-                "examples": {
-                  "Invalid expiration date": {
-                    "value": {
-                      "code": 400,
-                      "key": "invalid_expiration_date",
-                      "message": "Invalid Expiration Date",
-                      "details": "Expiration date cannot be set in the past",
-                      "request_id": "v-0c118b1611424ca899"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_add_remove_points_balance"
-              },
-              "examples": {
-                "Add points": {
-                  "value": {
-                    "points": 100,
-                    "expiration_type": "CUSTOM_DATE",
-                    "expiration_date": "2023-05-30"
-                  }
-                },
-                "Deduct points": {
-                  "value": {
-                    "points": -100
-                  }
-                }
-              }
-            }
-          },
-          "description": "Specify the point adjustment along with the expiration mechanism."
-        },
-        "description": "This method adds or removes balance to an existing loyalty card. The removal of points will consume the points that expire the soonest.",
-        "tags": [
-          "LOYALTIES API"
-        ]
-      }
-    },
-    "/loyalties/members/{memberId}/balance": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "MmFAzfDe"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "Unique loyalty card assigned to a particular customer."
-        }
-      ],
-      "post": {
-        "summary": "Add or Remove Loyalty Card Balance",
-        "operationId": "post-loyalties-members-memberId-balance",
-        "responses": {
-          "200": {
-            "description": "Returns a balance object.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_res_add_remove_points_balance"
-                },
-                "examples": {
-                  "Subtract Points": {
-                    "value": {
-                      "points": 100,
-                      "total": 13436,
-                      "balance": 13136,
-                      "type": "loyalty_card",
-                      "object": "balance",
-                      "related_object": {
-                        "type": "voucher",
-                        "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Returns an error if the expiration date was specified incorrectly in the request payload.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/e_error_no_translation"
-                },
-                "examples": {
-                  "Invalid payload": {
-                    "value": {
-                      "code": 400,
-                      "key": "invalid_payload",
-                      "message": "Invalid payload",
-                      "details": "Property .expiration_date cannot be recognized as a ISO-8601 compliant date",
-                      "request_id": "v-0c118c6f7c0e6751ab"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "description": "This method gives adds or removes balance to an existing loyalty card. The removal of points will consume the points that expire the soonest.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_add_remove_points_balance"
-              },
-              "examples": {
-                "Subtract points": {
-                  "value": {
-                    "points": -100
-                  }
-                },
-                "Add Points": {
-                  "value": {
-                    "points": 100,
-                    "expiration_type": "CUSTOM_DATE",
-                    "expiration_date": "2023-05-30"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Specify the point adjustment along with the expiration mechanism."
-        }
-      }
-    },
-    "/loyalties/{campaignId}/members/{memberId}/transfers": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "A unique identifier of the loyalty campaign containing the voucher to which the loyalty points will be sent (destination)."
-        },
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "A unique code identifying the loyalty card to which the user wants to transfer loyalty points (destination)."
-        }
-      ],
-      "post": {
-        "summary": "Transfer Loyalty Points",
-        "operationId": "post-loyalties-campaignId-members-memberId-transfers",
-        "responses": {
-          "200": {
-            "description": "Returns a loyalty card object for the loaded loyalty card, ie. the one that that points were transferred to from the other cards(s).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_obj_loyalty_card_object_non_expanded_categories"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                      "code": "MmFAzfDe",
-                      "campaign": "Proportional Earning Rules",
-                      "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                      "category": null,
-                      "category_id": "cat_0b6152ce12414820de",
-                      "categories": [],
-                      "type": "LOYALTY_CARD",
-                      "discount": null,
-                      "gift": null,
-                      "loyalty_card": {
-                        "points": 13441,
-                        "balance": 13141,
-                        "next_expiration_date": "2022-11-30",
-                        "next_expiration_points": 0
-                      },
-                      "start_date": null,
-                      "expiration_date": null,
-                      "validity_timeframe": null,
-                      "validity_day_of_week": null,
-                      "active": true,
-                      "additional_info": null,
-                      "metadata": {},
-                      "assets": {
-                        "qr": {
-                          "id": "U2FsdGVkX184kVdWUO/msrLg1G0MRf/Cs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk/dXm/QEJ/sulXKDlUMWf+MN7TRG5LB+wuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/qr/U2FsdGVkX184kVdWUO%2FmsrLg1G0MRf%2FCs6QwSN3f6kyWCOTGdijyq8OfUbUpcGx6fjdeIpTf2UilFGNG8aCWVk%2FdXm%2FQEJ%2FsulXKDlUMWf%2BMN7TRG5LB%2BwuzqTy7csDBfRoJn0fURpwU4A6VZZSwBQ%3D%3D"
-                        },
-                        "barcode": {
-                          "id": "U2FsdGVkX1/RGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW/cXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ==",
-                          "url": "https://dev.dl.voucherify.io/api/v1/assets/barcode/U2FsdGVkX1%2FRGZN9VwvkdI6B26PPZQZWjh33USr5NPMXbHuJVkxsH6TUyW%2FcXen1Lc7gaqik09BGiry0R4QIAP52jnxQuABOsW0HdYfglsLPY7IajGX5rJzZKDKuzioq2vRIPyuE6z03frAod7ptvQ%3D%3D"
-                        }
-                      },
-                      "is_referral_code": false,
-                      "created_at": "2022-02-18T14:03:59.954Z",
-                      "updated_at": "2022-11-28T17:58:25.607Z",
-                      "holder_id": "cust_sehkNIi8Uq2qQuRqSr7xn4Zi",
-                      "redemption": {
-                        "quantity": null,
-                        "redeemed_quantity": 1,
-                        "redeemed_points": 300,
-                        "object": "list",
-                        "url": "/v1/vouchers/MmFAzfDe/redemptions?page=1&limit=10"
-                      },
-                      "publish": {
-                        "object": "list",
-                        "count": 1,
-                        "url": "/v1/vouchers/MmFAzfDe/publications?page=1&limit=10"
-                      },
-                      "object": "voucher"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "description": "Transfer points between different loyalty cards. You need to provide the campaign ID and the loyalty card ID you want the points to be transferred to as path parameters in the URL. In the request body, you provide the loyalty cards you want the points to be transferred from and the number of points to transfer from each card.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_transfer_loyalty_points"
-              },
-              "examples": {
-                "Example": {
-                  "value": [
-                    {
-                      "code": "0PmQ7JQI",
-                      "points": 1
-                    },
-                    {
-                      "code": "kCeufB8i",
-                      "points": 1
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "description": "Provide the loyalty cards you want the points to be transferred from and the number of points to transfer from each card."
-        },
-        "tags": [
-          "LOYALTIES API"
-        ]
-      }
-    },
-    "/loyalties/{campaignId}/members/{memberId}/activities": {
+    "/loyalties/{campaignId}/members/{memberId}/redemption": {
       "parameters": [
         {
           "schema": {
@@ -57237,21 +57484,22 @@
           "description": "A code that identifies the loyalty card."
         }
       ],
-      "get": {
-        "summary": "Get Member Activities",
-        "operationId": "get-loyalties-campaignId-members-memberId-activities",
+      "post": {
+        "summary": "Redeem Reward",
+        "operationId": "post-loyalties-campaignId-members-memberId-redemption",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_get_member_activities"
+                  "$ref": "#/components/schemas/8_res_redeem_reward"
                 }
               }
             }
           }
         },
+        "description": "Exchange points from a loyalty card for a specified reward. This API method returns an assigned award in the response. It means that if a requesting customer gets a coupon code with a discount for the next order, that discount code will be visible in response as part of the reward object definition.",
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -57260,13 +57508,22 @@
             "$ref": "#/components/parameters/X-App-Token"
           }
         ],
-        "description": "Retrieves the list of activities for the given member ID related to voucher and customer who is a holder of the voucher.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_redeem_reward"
+              }
+            }
+          },
+          "description": "Specify the reward to be redeemed."
+        },
         "tags": [
           "LOYALTIES API"
         ]
       }
     },
-    "/loyalties/members/{memberId}/activities": {
+    "/loyalties/members/{memberId}/redemption": {
       "parameters": [
         {
           "schema": {
@@ -57279,21 +57536,44 @@
           "description": "Unique loyalty card assigned to a particular customer."
         }
       ],
-      "get": {
-        "summary": "Get Member Activities",
-        "operationId": "get-loyalties-members-memberId-activities",
+      "post": {
+        "summary": "Redeem Reward",
+        "operationId": "post-loyalties-members-memberId-redemption",
         "responses": {
           "200": {
-            "description": "Returns a list of event objects related to the loyalty card.",
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_get_member_activities"
+                  "$ref": "#/components/schemas/8_res_redeem_reward"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Returns an error indicating that a reward is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/e_400_missing_reward"
+                    },
+                    {
+                      "$ref": "#/components/schemas/e_400_missing_order"
+                    },
+                    {
+                      "$ref": "#/components/schemas/e_400_loyalty_card_points_exceeded"
+                    }
+                  ]
                 }
               }
             }
           }
         },
+        "tags": [
+          "LOYALTIES API"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/X-App-Id"
@@ -57302,10 +57582,16 @@
             "$ref": "#/components/parameters/X-App-Token"
           }
         ],
-        "description": "Retrieves a list of activities for the given loyalty card related to the loyalty and customer who is the holder of the loyalty card.",
-        "tags": [
-          "LOYALTIES API"
-        ]
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/8_req_redeem_reward"
+              }
+            }
+          },
+          "description": "Specify the reward to be redeemed."
+        }
       }
     },
     "/loyalties/{campaignId}/tiers": {
@@ -58476,292 +58762,6 @@
             "$ref": "#/components/parameters/X-App-Token"
           }
         ]
-      }
-    },
-    "/loyalties/{campaignId}/members/{memberId}/points-expiration": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string",
-            "example": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "The campaign ID or name of the loyalty campaign. You can either pass the campaign ID, which was assigned by Voucherify, or the `name` of the campaign as the path parameter value, e.g., `Loyalty%20Campaign`. "
-        },
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "memberId",
-          "in": "path",
-          "required": true,
-          "description": "Loyalty card code."
-        }
-      ],
-      "get": {
-        "summary": "Get Points Expiration",
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns a list of loyalty points expiration buckets along with an expiration date if the points are due to expire. No expiration date parameter is returned if the loyalty points bucket does not expire.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_res_get_points_expiration"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "object": "list",
-                      "data_ref": "data",
-                      "data": [
-                        {
-                          "id": "lopb_ERSwDxeWTlvWwFrn3AtJxt3s",
-                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "bucket": {
-                            "total_points": 2
-                          },
-                          "status": "ACTIVE",
-                          "expires_at": "2022-11-25",
-                          "created_at": "2022-11-25T09:10:20.994Z",
-                          "object": "loyalty_points_bucket"
-                        },
-                        {
-                          "id": "lopb_zdeIBq3EsnPnRSDa7Tyyb6X2",
-                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "bucket": {
-                            "total_points": 12
-                          },
-                          "status": "ACTIVE",
-                          "expires_at": "2022-11-30",
-                          "created_at": "2022-11-21T13:49:54.949Z",
-                          "object": "loyalty_points_bucket"
-                        },
-                        {
-                          "id": "lopb_Mg80vhZtqHFItWlJFYZ2rJAS",
-                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "bucket": {
-                            "total_points": 0
-                          },
-                          "status": "ACTIVE",
-                          "expires_at": "2023-05-30",
-                          "created_at": "2022-06-09T11:07:07.344Z",
-                          "updated_at": "2022-08-30T08:34:45.989Z",
-                          "object": "loyalty_points_bucket"
-                        },
-                        {
-                          "id": "lopb_dQE1TwyTkHAJDlVCPlqSC0nu",
-                          "voucher_id": "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                          "campaign_id": "camp_7s3uXI44aKfIk5IhmeOPr6ic",
-                          "bucket": {
-                            "total_points": 13124
-                          },
-                          "status": "ACTIVE",
-                          "created_at": "2022-02-28T12:13:57.749Z",
-                          "updated_at": "2022-11-25T09:09:51.136Z",
-                          "object": "loyalty_points_bucket"
-                        }
-                      ],
-                      "total": 4
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-loyalties-campaignId-members-memberId-points-expiration",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          },
-          {
-            "$ref": "#/components/parameters/limit"
-          },
-          {
-            "$ref": "#/components/parameters/page"
-          }
-        ],
-        "description": "Retrieve loyalty point expiration buckets for a given loyalty card."
-      }
-    },
-    "/loyalties/{campaignId}/points-expiration/export": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "campaignId",
-          "in": "path",
-          "required": true,
-          "description": "Unique campaign ID or name."
-        }
-      ],
-      "post": {
-        "summary": "Create Points Expiration Export",
-        "operationId": "post-loyalties-campaignId-points-expiration-export",
-        "responses": {
-          "200": {
-            "description": "Returns an object with the export ID of the scheduled generation of CSV file with exported points expirations. You can use either the <!-- [Get Export](OpenAPI.json/paths/~1exports~1{exportId}/get) -->[Get Export](ref:get-export) endpoint to view the status and obtain the URL of the CSV file or <!-- [Download Export](OpenAPI.json/paths/~1exports~1{export_Id}/get) -->[Download Export](ref:download-export) endpoint to download the CSV file.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/8_obj_export_object_points_expiration"
-                },
-                "examples": {
-                  "Specific Vouchers": {
-                    "value": {
-                      "id": "exp_zC3eXAFss17XTMzMkkov4KGq",
-                      "object": "export",
-                      "created_at": "2022-11-28T13:00:23.621Z",
-                      "status": "SCHEDULED",
-                      "channel": "API",
-                      "exported_object": "points_expiration",
-                      "parameters": {
-                        "order": "-expires_at",
-                        "fields": [
-                          "id",
-                          "campaign_id",
-                          "voucher_id",
-                          "status",
-                          "expires_at",
-                          "points"
-                        ],
-                        "filters": {
-                          "junction": "and",
-                          "voucher_id": {
-                            "conditions": {
-                              "$in": [
-                                "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                                "v_YLn0WVWXSXbUfDvxgrgUbtfJ3SQIY655"
-                              ]
-                            }
-                          }
-                        }
-                      },
-                      "result": null,
-                      "user_id": null
-                    }
-                  },
-                  "Specific Campaign": {
-                    "value": {
-                      "id": "exp_kfwVDMsavDHl2vOY6vH9q7P7",
-                      "object": "export",
-                      "created_at": "2022-11-28T16:46:34.148Z",
-                      "status": "SCHEDULED",
-                      "channel": "API",
-                      "exported_object": "points_expiration",
-                      "parameters": {
-                        "order": "-expires_at",
-                        "fields": [
-                          "id",
-                          "campaign_id",
-                          "voucher_id",
-                          "status",
-                          "expires_at",
-                          "points"
-                        ],
-                        "filters": {
-                          "junction": "and",
-                          "campaign_id": {
-                            "conditions": {
-                              "$is": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
-                            }
-                          }
-                        }
-                      },
-                      "result": null,
-                      "user_id": null
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "LOYALTIES API"
-        ],
-        "description": "Schedule the generation of a points expiration CSV file for a particular campaign.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/X-App-Id"
-          },
-          {
-            "$ref": "#/components/parameters/X-App-Token"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/8_req_export_points_expirations"
-              },
-              "examples": {
-                "Specific Vouchers": {
-                  "value": {
-                    "parameters": {
-                      "fields": [
-                        "id",
-                        "campaign_id",
-                        "voucher_id",
-                        "status",
-                        "expires_at",
-                        "points"
-                      ],
-                      "order": "-expires_at",
-                      "filters": {
-                        "junction": "and",
-                        "voucher_id": {
-                          "conditions": {
-                            "$in": [
-                              "v_0aMj6Mdp0i3zuXrd9NnBKboc7746mlgF",
-                              "v_YLn0WVWXSXbUfDvxgrgUbtfJ3SQIY655"
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "Specific campaign": {
-                  "value": {
-                    "parameters": {
-                      "fields": [
-                        "id",
-                        "campaign_id",
-                        "voucher_id",
-                        "status",
-                        "expires_at",
-                        "points"
-                      ],
-                      "order": "-expires_at",
-                      "filters": {
-                        "junction": "and",
-                        "campaign_id": {
-                          "conditions": {
-                            "$is": "camp_7s3uXI44aKfIk5IhmeOPr6ic"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "description": "Specify the data filters, types of data to return and order in which the results should be returned."
-        }
       }
     },
     "/customers": {


### PR DESCRIPTION
- Added markdown files of API endpoints to be able to manage additional content and/or change the order of the documents because readme by default organizes the endpoints in the order they appear in the OpenAPI, but sometimes we want to be able to re-order the endpoints. 
    - Validations, Stackable Discounts, Rewards, Redemptions, Publications, Promotions, and partially Loyalties API
- Reordering loyalties endpoints within API spec.