### PR TITLE
Update Markdown docs for Endpoints

### DIFF
--- a/docs/reference-docs/ASYNC-ACTIONS-API-Get-Async-Action.md
+++ b/docs/reference-docs/ASYNC-ACTIONS-API-Get-Async-Action.md
@@ -1,0 +1,9 @@
+---
+title: Get Async Action
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-async-action
+parentDoc: 639ba2658407100061f5fabf
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/ASYNC-ACTIONS-API-List-Async-Actions.md
+++ b/docs/reference-docs/ASYNC-ACTIONS-API-List-Async-Actions.md
@@ -1,0 +1,9 @@
+---
+title: List Async Actions
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-async-actions
+parentDoc: 639ba2658407100061f5fabf
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/CATEGORIES-API-Create-Category.md
+++ b/docs/reference-docs/CATEGORIES-API-Create-Category.md
@@ -1,0 +1,9 @@
+---
+title: Create Category
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-category
+parentDoc: 639ba2658407100061f5fac1
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/CATEGORIES-API-Delete-Category.md
+++ b/docs/reference-docs/CATEGORIES-API-Delete-Category.md
@@ -1,0 +1,9 @@
+---
+title: Delete Category
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-category
+parentDoc: 639ba2658407100061f5fac1
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/CATEGORIES-API-Get-Category.md
+++ b/docs/reference-docs/CATEGORIES-API-Get-Category.md
@@ -1,0 +1,9 @@
+---
+title: Get Category
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-category
+parentDoc: 639ba2658407100061f5fac1
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/CATEGORIES-API-List-Categories.md
+++ b/docs/reference-docs/CATEGORIES-API-List-Categories.md
@@ -1,0 +1,9 @@
+---
+title: List Categories
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-categories
+parentDoc: 639ba2658407100061f5fac1
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/CATEGORIES-API-Update-Category.md
+++ b/docs/reference-docs/CATEGORIES-API-Update-Category.md
@@ -1,0 +1,9 @@
+---
+title: Update Category
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-category
+parentDoc: 639ba2658407100061f5fac1
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/CONSENTS-API-List-Consents-Client-Side.md
+++ b/docs/reference-docs/CONSENTS-API-List-Consents-Client-Side.md
@@ -1,0 +1,9 @@
+---
+title: List Consents (client-side)
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-consents-client-side
+parentDoc: 639ba2658407100061f5fabe
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/CONSENTS-API-List-Consents.md
+++ b/docs/reference-docs/CONSENTS-API-List-Consents.md
@@ -1,0 +1,9 @@
+---
+title: List Consents
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-consents
+parentDoc: 639ba2658407100061f5fabe
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/CUSTOMERS-API-Create-Customer.md
+++ b/docs/reference-docs/CUSTOMERS-API-Create-Customer.md
@@ -1,0 +1,9 @@
+---
+title: Create Customer
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-customer
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/CUSTOMERS-API-Delete-Customer-Permanently.md
+++ b/docs/reference-docs/CUSTOMERS-API-Delete-Customer-Permanently.md
@@ -1,0 +1,9 @@
+---
+title: Delete Customer Permanently
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-customer-permanently
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/CUSTOMERS-API-Import-Customers-Using-CSV.md
+++ b/docs/reference-docs/CUSTOMERS-API-Import-Customers-Using-CSV.md
@@ -1,0 +1,9 @@
+---
+title: Import and Update Customers using CSV
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-customers-using-csv
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/CUSTOMERS-API-List-Customer-Activities.md
+++ b/docs/reference-docs/CUSTOMERS-API-List-Customer-Activities.md
@@ -1,0 +1,9 @@
+---
+title: List Customer Activities
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-customer-activities
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/CUSTOMERS-API-List-Customer-Segments.md
+++ b/docs/reference-docs/CUSTOMERS-API-List-Customer-Segments.md
@@ -1,0 +1,9 @@
+---
+title: List Customer's Segments
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-customer-segments
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/CUSTOMERS-API-List-Customers.md
+++ b/docs/reference-docs/CUSTOMERS-API-List-Customers.md
@@ -1,0 +1,9 @@
+---
+title: List Customers
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-customers
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/CUSTOMERS-API-List-Get-Customer.md
+++ b/docs/reference-docs/CUSTOMERS-API-List-Get-Customer.md
@@ -1,0 +1,9 @@
+---
+title: Get Customer
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-customer
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/CUSTOMERS-API-Update-Customer-Consents.md
+++ b/docs/reference-docs/CUSTOMERS-API-Update-Customer-Consents.md
@@ -1,0 +1,9 @@
+---
+title: Update Customer's consents
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-customers-consents
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 13
+---

--- a/docs/reference-docs/CUSTOMERS-API-Update-Customer.md
+++ b/docs/reference-docs/CUSTOMERS-API-Update-Customer.md
@@ -1,0 +1,9 @@
+---
+title: Update Customer
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-customer
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/CUSTOMERS-API-Update-Customers-Consents-Client-Side.md
+++ b/docs/reference-docs/CUSTOMERS-API-Update-Customers-Consents-Client-Side.md
@@ -1,0 +1,9 @@
+---
+title: Update Customer's consents (client-side)
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-customers-consents-client-side
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 14
+---

--- a/docs/reference-docs/CUSTOMERS-API-Update-Customers-In-Bulk.md
+++ b/docs/reference-docs/CUSTOMERS-API-Update-Customers-In-Bulk.md
@@ -1,0 +1,9 @@
+---
+title: Update Customers in bulk
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-customers-in-bulk
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/CUSTOMERS-API-Update-Customers-Metadata-In-Bulk.md
+++ b/docs/reference-docs/CUSTOMERS-API-Update-Customers-Metadata-In-Bulk.md
@@ -1,0 +1,9 @@
+---
+title: Update Customers Metadata in bulk
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-customers-metadata-in-bulk
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 12
+---

--- a/docs/reference-docs/CUSTOMES-API-Delete-Customer.md
+++ b/docs/reference-docs/CUSTOMES-API-Delete-Customer.md
@@ -1,0 +1,9 @@
+---
+title: Delete Customer
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-customer
+parentDoc: 639ba2658407100061f5fab7
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/EVENTS-API-Track-Custom-Event.md
+++ b/docs/reference-docs/EVENTS-API-Track-Custom-Event.md
@@ -1,0 +1,9 @@
+---
+title: Track Custom Event
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: track-custom-event
+parentDoc: 639ba2658407100061f5fabd
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/EXPORTS-API-Create-Export.md
+++ b/docs/reference-docs/EXPORTS-API-Create-Export.md
@@ -1,0 +1,9 @@
+---
+title: Create Export
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-export
+parentDoc: 639ba2658407100061f5fac0
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/EXPORTS-API-Delete-Export.md
+++ b/docs/reference-docs/EXPORTS-API-Delete-Export.md
@@ -1,0 +1,9 @@
+---
+title: Delete Export
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-export
+parentDoc: 639ba2658407100061f5fac0
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/EXPORTS-API-Download-Export.md
+++ b/docs/reference-docs/EXPORTS-API-Download-Export.md
@@ -1,0 +1,9 @@
+---
+title: Download Export
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: download-export
+parentDoc: 639ba2658407100061f5fac0
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/EXPORTS-API-Get-Export.md
+++ b/docs/reference-docs/EXPORTS-API-Get-Export.md
@@ -1,0 +1,9 @@
+---
+title: Get Export
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-export
+parentDoc: 639ba2658407100061f5fac0
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/EXPORTS-API-List-Exports.md
+++ b/docs/reference-docs/EXPORTS-API-List-Exports.md
@@ -1,0 +1,9 @@
+---
+title: List Exports
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-exports
+parentDoc: 639ba2658407100061f5fac0
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/LOYALTIES-API-Add-Member.md
+++ b/docs/reference-docs/LOYALTIES-API-Add-Member.md
@@ -1,0 +1,9 @@
+---
+title: Add Member
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-member
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 12
+---

--- a/docs/reference-docs/LOYALTIES-API-Add-Or-Remove-Loyalty-Card-Balance-1.md
+++ b/docs/reference-docs/LOYALTIES-API-Add-Or-Remove-Loyalty-Card-Balance-1.md
@@ -1,0 +1,9 @@
+---
+title: Add or Remove Loyalty Card Balance
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-remove-loyalty-card-balance-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 16
+---

--- a/docs/reference-docs/LOYALTIES-API-Add-Or-Remove-Loyalty-Card-Balance.md
+++ b/docs/reference-docs/LOYALTIES-API-Add-Or-Remove-Loyalty-Card-Balance.md
@@ -1,0 +1,9 @@
+---
+title: Add or Remove Loyalty Card Balance
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: add-remove-loyalty-card-balance
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 15
+---

--- a/docs/reference-docs/LOYALTIES-API-Create-Earning-Rule.md
+++ b/docs/reference-docs/LOYALTIES-API-Create-Earning-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Create Earning Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-earning-rule
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 22
+---

--- a/docs/reference-docs/LOYALTIES-API-Create-Points-Expiration-Export.md
+++ b/docs/reference-docs/LOYALTIES-API-Create-Points-Expiration-Export.md
@@ -1,0 +1,9 @@
+---
+title: Create Points Expiration Export
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-points-expiration-export
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 19
+---

--- a/docs/reference-docs/LOYALTIES-API-Delete-Earning-Rule.md
+++ b/docs/reference-docs/LOYALTIES-API-Delete-Earning-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Delete Earning Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-earning-rule
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 24
+---

--- a/docs/reference-docs/LOYALTIES-API-Delete-Reward-Assignment.md
+++ b/docs/reference-docs/LOYALTIES-API-Delete-Reward-Assignment.md
@@ -1,0 +1,9 @@
+---
+title: Delete Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-reward-assignment-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 34
+---

--- a/docs/reference-docs/LOYALTIES-API-Disable-Earning-Rule.md
+++ b/docs/reference-docs/LOYALTIES-API-Disable-Earning-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Disable Earning Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: disable-earning-rule
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 26
+---

--- a/docs/reference-docs/LOYALTIES-API-Enable-Earning-Rule.md
+++ b/docs/reference-docs/LOYALTIES-API-Enable-Earning-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Enable Earning Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: enable-earning-rule
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 25
+---

--- a/docs/reference-docs/LOYALTIES-API-GET-Reward-Assignment-2.md
+++ b/docs/reference-docs/LOYALTIES-API-GET-Reward-Assignment-2.md
@@ -1,0 +1,9 @@
+---
+title: Get Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-reward-assignment-2
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 32
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Earning-Rule.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Earning-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Get Earning Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-earning-rule
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 21
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Loyalty-Tier.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Loyalty-Tier.md
@@ -1,0 +1,9 @@
+---
+title: Get Loyalty Tier
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-loyalty-tier
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 38
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Member-1.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Member-1.md
@@ -1,0 +1,9 @@
+---
+title: Get Member
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-member-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Member-Activities-1.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Member-Activities-1.md
@@ -1,0 +1,9 @@
+---
+title: Get Member Activities
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-member-activities-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 13
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Member-Activities.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Member-Activities.md
@@ -1,0 +1,9 @@
+---
+title: Get Member Activities
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-member-activities
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 14
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Member.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Member.md
@@ -1,0 +1,9 @@
+---
+title: Get Member
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-member
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Points-Expiration.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Points-Expiration.md
@@ -1,0 +1,9 @@
+---
+title: Get Points Expiration
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-points-expiration
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 18
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Reward-Assignment-1.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Reward-Assignment-1.md
@@ -1,0 +1,9 @@
+---
+title: Get Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-reward-assignment-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 31
+---

--- a/docs/reference-docs/LOYALTIES-API-Get-Reward-Details.md
+++ b/docs/reference-docs/LOYALTIES-API-Get-Reward-Details.md
@@ -1,0 +1,9 @@
+---
+title: Get Reward Details
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-reward-details
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 28
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Earning-Rules.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Earning-Rules.md
@@ -1,0 +1,9 @@
+---
+title: List Earning Rules
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-earning-rules
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 20
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Loyalty-Tier-Earning-Rules.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Loyalty-Tier-Earning-Rules.md
@@ -1,0 +1,9 @@
+---
+title: List Loyalty Tier Earning Rules
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-loyalty-tier-earning-rules
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 40
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Loyalty-Tier-Rewards.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Loyalty-Tier-Rewards.md
@@ -1,0 +1,9 @@
+---
+title: List Loyalty Tier Rewards
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-loyalty-tier-rewards
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 41
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Loyalty-Tiers.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Loyalty-Tiers.md
@@ -1,0 +1,9 @@
+---
+title: List Loyalty Tiers
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-loyalty-tiers
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 37
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Member-Rewards.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Member-Rewards.md
@@ -1,0 +1,9 @@
+---
+title: List Member Rewards
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-member-rewards
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 27
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Members-Loyalty-Tier.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Members-Loyalty-Tier.md
@@ -1,0 +1,9 @@
+---
+title: List Member's Loyalty Tiers
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-member-loyalty-tier
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 39
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Members.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Members.md
@@ -1,0 +1,9 @@
+---
+title: List Members
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-members
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Reward-Assignments-1.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Reward-Assignments-1.md
@@ -1,0 +1,9 @@
+---
+title: List Reward Assignments
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-reward-assignments-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 29
+---

--- a/docs/reference-docs/LOYALTIES-API-List-Reward-Assignments-2.md
+++ b/docs/reference-docs/LOYALTIES-API-List-Reward-Assignments-2.md
@@ -1,0 +1,9 @@
+---
+title: List Reward Assignments
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-reward-assignments-2
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 30
+---

--- a/docs/reference-docs/LOYALTIES-API-Redeem-Reward.md
+++ b/docs/reference-docs/LOYALTIES-API-Redeem-Reward.md
@@ -1,0 +1,9 @@
+---
+title: Redeem Reward
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: redeem-reward
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 36
+---

--- a/docs/reference-docs/LOYALTIES-API-Reedem-Reward-1.md
+++ b/docs/reference-docs/LOYALTIES-API-Reedem-Reward-1.md
@@ -1,0 +1,9 @@
+---
+title: Redeem Reward
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: redeem-reward-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 35
+---

--- a/docs/reference-docs/LOYALTIES-API-Transfer-Loyalty-Points.md
+++ b/docs/reference-docs/LOYALTIES-API-Transfer-Loyalty-Points.md
@@ -1,0 +1,9 @@
+---
+title: Transfer Loyalty Points
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: transfer-points
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 17
+---

--- a/docs/reference-docs/LOYALTIES-API-Update-Earning-Rule.md
+++ b/docs/reference-docs/LOYALTIES-API-Update-Earning-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Update Earning Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-earning-rule
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 23
+---

--- a/docs/reference-docs/LOYALTIES-API-Update-Reward-Assignment-1.md
+++ b/docs/reference-docs/LOYALTIES-API-Update-Reward-Assignment-1.md
@@ -1,0 +1,9 @@
+---
+title: Update Reward Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-reward-assignment-1
+parentDoc: 639ba2658407100061f5fab6
+hidden: false
+order: 33
+---

--- a/docs/reference-docs/METADATA-SCHEMAS-API-Get-Metadata-Schema.md
+++ b/docs/reference-docs/METADATA-SCHEMAS-API-Get-Metadata-Schema.md
@@ -1,0 +1,9 @@
+---
+title: Get Metadata Schema
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-metadata-schema
+parentDoc: 639ba2658407100061f5fac2
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/METADATA-SCHEMAS-API-List-Metadata-Schemas.md
+++ b/docs/reference-docs/METADATA-SCHEMAS-API-List-Metadata-Schemas.md
@@ -1,0 +1,9 @@
+---
+title: List Metadata Schemas
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-metadata-schemas
+parentDoc: 639ba2658407100061f5fac2
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/ORDERS-API-Create-Order.md
+++ b/docs/reference-docs/ORDERS-API-Create-Order.md
@@ -1,0 +1,9 @@
+---
+title: Create Order
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-order
+parentDoc: 639ba2658407100061f5fab8
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/ORDERS-API-Create-Orders-Export.md
+++ b/docs/reference-docs/ORDERS-API-Create-Orders-Export.md
@@ -1,0 +1,9 @@
+---
+title: Create Orders Export
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-order-export
+parentDoc: 639ba2658407100061f5fab8
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/ORDERS-API-Get-Order.md
+++ b/docs/reference-docs/ORDERS-API-Get-Order.md
@@ -1,0 +1,9 @@
+---
+title: Get Order
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-order
+parentDoc: 639ba2658407100061f5fab8
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/ORDERS-API-Import-Orders.md
+++ b/docs/reference-docs/ORDERS-API-Import-Orders.md
@@ -1,0 +1,9 @@
+---
+title: Import Orders
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-orders
+parentDoc: 639ba2658407100061f5fab8
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/ORDERS-API-List-Orders.md
+++ b/docs/reference-docs/ORDERS-API-List-Orders.md
@@ -1,0 +1,9 @@
+---
+title: List Orders
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-orders
+parentDoc: 639ba2658407100061f5fab8
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/ORDERS-API-Update-Order.md
+++ b/docs/reference-docs/ORDERS-API-Update-Order.md
@@ -1,0 +1,9 @@
+---
+title: Update Order
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-order
+parentDoc: 639ba2658407100061f5fab8
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/PRODUCT-COLLECTIONS-API-Delete-Product-Collection.md
+++ b/docs/reference-docs/PRODUCT-COLLECTIONS-API-Delete-Product-Collection.md
@@ -1,0 +1,9 @@
+---
+title: Delete Product Collection
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-product-collection
+parentDoc: 639ba2658407100061f5faba
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/PRODUCT-COLLECTIONS-API-List-Product-Collections.md
+++ b/docs/reference-docs/PRODUCT-COLLECTIONS-API-List-Product-Collections.md
@@ -1,0 +1,9 @@
+---
+title: List Product Collections
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-product-collections
+parentDoc: 639ba2658407100061f5faba
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/PRODUCT-COLLECTIONS-API-List-Products-In-Collection.md
+++ b/docs/reference-docs/PRODUCT-COLLECTIONS-API-List-Products-In-Collection.md
@@ -1,0 +1,9 @@
+---
+title: List Products in Collection
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-products-in-collection
+parentDoc: 639ba2658407100061f5faba
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/PRODUCT-COLLECTIONS-Get-Product-Collection.md
+++ b/docs/reference-docs/PRODUCT-COLLECTIONS-Get-Product-Collection.md
@@ -1,0 +1,9 @@
+---
+title: Get Product Collection
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-product-collection
+parentDoc: 639ba2658407100061f5faba
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/PRODUCTS-API-Create-Product.md
+++ b/docs/reference-docs/PRODUCTS-API-Create-Product.md
@@ -1,0 +1,9 @@
+---
+title: Create Product
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-product
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/PRODUCTS-API-Create-SKU.md
+++ b/docs/reference-docs/PRODUCTS-API-Create-SKU.md
@@ -1,0 +1,9 @@
+---
+title: Create SKU
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-sku
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 11
+---

--- a/docs/reference-docs/PRODUCTS-API-Delete-Product.md
+++ b/docs/reference-docs/PRODUCTS-API-Delete-Product.md
@@ -1,0 +1,9 @@
+---
+title: Delete Product
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-product
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/PRODUCTS-API-Delete-SKU.md
+++ b/docs/reference-docs/PRODUCTS-API-Delete-SKU.md
@@ -1,0 +1,9 @@
+---
+title: Delete SKU
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-sku
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 13
+---

--- a/docs/reference-docs/PRODUCTS-API-Get-Product.md
+++ b/docs/reference-docs/PRODUCTS-API-Get-Product.md
@@ -1,0 +1,9 @@
+---
+title: Get Product
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-product
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/PRODUCTS-API-Get-SKU.md
+++ b/docs/reference-docs/PRODUCTS-API-Get-SKU.md
@@ -1,0 +1,9 @@
+---
+title: Get SKU
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-sku
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/PRODUCTS-API-Import-Products-Using-CSV.md
+++ b/docs/reference-docs/PRODUCTS-API-Import-Products-Using-CSV.md
@@ -1,0 +1,9 @@
+---
+title: Import Products using CSV
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-products-using-csv
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 14
+---

--- a/docs/reference-docs/PRODUCTS-API-Import-SKUS-Using-CSV.md
+++ b/docs/reference-docs/PRODUCTS-API-Import-SKUS-Using-CSV.md
@@ -1,0 +1,9 @@
+---
+title: Import SKUs using CSV
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: import-skus-using-csv
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 15
+---

--- a/docs/reference-docs/PRODUCTS-API-List-Products.md
+++ b/docs/reference-docs/PRODUCTS-API-List-Products.md
@@ -1,0 +1,9 @@
+---
+title: List Products
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-products
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/PRODUCTS-API-List-SKUS-In-Product.md
+++ b/docs/reference-docs/PRODUCTS-API-List-SKUS-In-Product.md
@@ -1,0 +1,9 @@
+---
+title: List SKUs in Product
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-skus-in-product
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/PRODUCTS-API-Update-Product.md
+++ b/docs/reference-docs/PRODUCTS-API-Update-Product.md
@@ -1,0 +1,9 @@
+---
+title: Update Product
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-product
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 5
+---

--- a/docs/reference-docs/PRODUCTS-API-Update-Products-In-Bulk.md
+++ b/docs/reference-docs/PRODUCTS-API-Update-Products-In-Bulk.md
@@ -1,0 +1,9 @@
+---
+title: Update Products In Bulk
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-products-in-bulk
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/PRODUCTS-API-Update-Products-Metadata-In-Bulk.md
+++ b/docs/reference-docs/PRODUCTS-API-Update-Products-Metadata-In-Bulk.md
@@ -1,0 +1,9 @@
+---
+title: Update Products Metadata in bulk
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-products-metadata-in-bulk
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/PRODUCTS-API-Update-SKU.md
+++ b/docs/reference-docs/PRODUCTS-API-Update-SKU.md
@@ -1,0 +1,9 @@
+---
+title: Update SKU
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-sku
+parentDoc: 639ba2658407100061f5fab9
+hidden: false
+order: 12
+---

--- a/docs/reference-docs/SEGMENTS-API-Create-Segment.md
+++ b/docs/reference-docs/SEGMENTS-API-Create-Segment.md
@@ -1,0 +1,9 @@
+---
+title: Create Segment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-segment
+parentDoc: 639ba2658407100061f5fabc
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/SEGMENTS-API-Delete-Segment.md
+++ b/docs/reference-docs/SEGMENTS-API-Delete-Segment.md
@@ -1,0 +1,9 @@
+---
+title: Delete Segment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-segment
+parentDoc: 639ba2658407100061f5fabc
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/SEGMENTS-API-Get-Segment.md
+++ b/docs/reference-docs/SEGMENTS-API-Get-Segment.md
@@ -1,0 +1,9 @@
+---
+title: Get Segment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-segment
+parentDoc: 639ba2658407100061f5fabc
+hidden: false
+order: 1
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-Create-Validation-Rule.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-Create-Validation-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Create Validation Rules
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-validation-rules
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 4
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-Create-Validation-Rules-Assignments.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-Create-Validation-Rules-Assignments.md
@@ -1,0 +1,9 @@
+---
+title: Create Validation Rules Assignments
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: create-validation-rule-assignment
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 9
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-Delete-Validation-Rule-Assignment.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-Delete-Validation-Rule-Assignment.md
@@ -1,0 +1,9 @@
+---
+title: Delete Validation Rule Assignment
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-validation-rule-assignment
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 10
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-Delete-Validation-Rule.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-Delete-Validation-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Delete Validation Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: delete-validation-rules
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 6
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-Get-Validation-Rule.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-Get-Validation-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Get Validation Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: get-validation-rule
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 3
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-List-Validation-Rule-Assignments.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-List-Validation-Rule-Assignments.md
@@ -1,0 +1,9 @@
+---
+title: List Validation Rule Assignments
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-validation-rule-assignments
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 8
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-List-Validation-Rules-Assignments.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-List-Validation-Rules-Assignments.md
@@ -1,0 +1,9 @@
+---
+title: List Validation Rules' Assignment(s)
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-validation-rules-assignments
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 7
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-List-Validation-Rules.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-List-Validation-Rules.md
@@ -1,0 +1,9 @@
+---
+title: List Validation Rules
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: list-validation-rules
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 2
+---

--- a/docs/reference-docs/VALIDATION-RULES-API-Update-Validation-Rule.md
+++ b/docs/reference-docs/VALIDATION-RULES-API-Update-Validation-Rule.md
@@ -1,0 +1,9 @@
+---
+title: Update Validation Rule
+type: endpoint
+category: 639ba2628407100061f5faac
+slug: update-validation-rule
+parentDoc: 639ba2658407100061f5fabb
+hidden: false
+order: 5
+---

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -54523,7 +54523,7 @@
         "description": "Returns a list of all earning rules within a given campaign."
       },
       "post": {
-        "summary": "Create Earning Rules",
+        "summary": "Create Earning Rule",
         "tags": [
           "LOYALTIES API"
         ],
@@ -65237,7 +65237,7 @@
     },
     "/consents#": {
       "get": {
-        "summary": "List Consents (client)",
+        "summary": "List Consents (client-side)",
         "tags": [
           "CONSENTS API"
         ],


### PR DESCRIPTION
Added markdown files of API endpoints to be able to manage additional content and/or change the order of the documents because readme by default organizes the endpoints in the order they appear in the OpenAPI, but sometimes we want to be able to re-order the endpoints.

- Async Actions
- Categories
- Consents
- Customers
- Events
- Exports
- Loyalties
- Metadata Schemas
- Orders
- Product Collections
- Products
- Segments
- Validation Rules