### PR TITLE
Replace Version with API ID in syncing file

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Update API Reference Docs
         uses: readmeio/rdme@v8.4.0
         with:
-          rdme: openapi https://raw.githubusercontent.com/voucherifyio/voucherify-openapi/master/reference/OpenAPI.json --key=${{ secrets.README_API_KEY }} --version=${{ secrets.README_MAIN_VERSION }} --update
+          rdme: openapi https://raw.githubusercontent.com/voucherifyio/voucherify-openapi/master/reference/OpenAPI.json --key=${{ secrets.README_API_KEY }} --id=${{ secrets.API_DEFINITION_ID }}
 
        # First we're going to perform a dry run of syncing process.
        # We do this on every push to ensure that an actual sync will work properly


### PR DESCRIPTION
Substituted API ID for version to attempt to get rid of multiple API definitions rdme error.