### PR TITLE
Updated validation rules endpoint.

### DIFF
--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -64853,7 +64853,7 @@
         "description": "This method deletes a validation rule."
       }
     },
-    "v1/validation-rules-assignments": {
+    "/v1/validation-rules-assignments": {
       "parameters": [],
       "get": {
         "summary": "List Validation Rules' Assignment(s)",


### PR DESCRIPTION
Updated validation rules endpoint because it was missing the forward `/` slash.