### PR TITLE
Pz/types 007 - EarningRules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 20230905 - Exports API
+
+**New models**
+- LoyaltiesEarningRulesResponseCommon
+- LoyaltyFixed
+- LoyaltyProportionalOrderAmount
+- LoyaltyProportionalOrderTotalAmount
+- LoyaltyProportionalOrderMetadata
+- LoyaltyProportionalOrderItemsQuantity
+- LoyaltyProportionalOrderItemsAmount
+- LoyaltyProportionalOrderItemsSubtotalAmount
+- LoyaltyProportionalOrder
+- LoyaltyProportionalOrderItems
+- LoyaltyProportionalCustomer
+- LoyaltyProportionalCustomEvent
+- LoyaltyProportional
+- LoyaltiesEarningRulesResponse
+- LoyaltiesEnableEarningRulesResponse
+- LoyaltiesDisableEarningRulesResponse
+- LoyaltiesUpdateEarningRuleResponse
+- LoyaltiesCreateEarningRuleResponse
+- LoyaltiesListEarningRulesResponse
+- LoyaltiesEarningRulesEvent
+- LoyaltiesCreateEarningRule
+- LoyaltiesUpdateEarningRule
+
+**Endpoint changes**
+- /v1/loyalties/{campaignId}/earning-rules
+  - GET
+    - New response schema: `LoyaltiesListEarningRulesResponse` (old one: `8_res_list_earning_rules`)
+    - POST
+      - New request schema: `LoyaltiesCreateEarningRule` (old one: `8_req_create_earning_rules`)
+      - New response schema: `LoyaltiesCreateEarningRuleResponse` (old one: `8_obj_earning_rule_object`)
+- /v1/loyalties/{campaignId}/earning-rules/{earningRuleId}
+  - GET
+    - New response schema: `LoyaltiesEarningRulesResponse` (old one: `8_obj_earning_rule_object`)
+  - PUT
+    - New request schema: `LoyaltiesUpdateEarningRule` (old one: `8_req_update_earning_rule`)
+    - New response schema: `LoyaltiesUpdateEarningRuleResponse` (old one: `8_obj_earning_rule_object`)
+- /v1/loyalties/{campaignId}/earning-rules/{earningRuleId}/enable
+  - POST
+    - New response schema: `LoyaltiesEnableEarningRulesResponse` (old one: `8_obj_earning_rule_object_no_validation_rule`)
+- /v1/loyalties/{campaignId}/earning-rules/{earningRuleId}/disable
+    - POST
+        - New response schema: `LoyaltiesDisableEarningRulesResponse` (old one: `8_obj_earning_rule_object_no_validation_rule`)
+
 ## 20230823 - New Endpoints
 
 ### Introduced new endpoints and related object schemas

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -39165,6 +39165,1024 @@
           }
         }
       },
+      "LoyaltiesEarningRulesResponseCommon": {
+        "title": "LoyaltiesEarningRulesResponseCommon",
+        "x-stoplight": {
+          "id": "4bdaduf4ch3gv"
+        },
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "loyalty": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LoyaltyFixed"
+              },
+              {
+                "$ref": "#/components/schemas/LoyaltyProportional"
+              }
+            ]
+          },
+          "event": {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesEvent"
+          },
+          "custom_event": {
+            "type": "object",
+            "properties": {
+              "schema_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_id"
+            ]
+          },
+          "segment": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          "source": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "object_id",
+              "object_type"
+            ],
+            "properties": {
+              "banner": {
+                "type": "string"
+              },
+              "object_id": {
+                "type": "string"
+              },
+              "object_type": {
+                "type": "string"
+              }
+            }
+          },
+          "loyalty_tier": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          "object": {
+            "type": "string",
+            "default": "earning_rule",
+            "pattern": "earning_rule"
+          },
+          "automation_id": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "expiration_date": {
+            "type": "string"
+          },
+          "validity_timeframe": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "duration": {
+                "type": "string"
+              },
+              "interval": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "duration",
+              "interval"
+            ]
+          },
+          "validity_day_of_week": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "validation_rule_id",
+          "loyalty",
+          "source",
+          "object",
+          "automation_id",
+          "metadata"
+        ]
+      },
+      "LoyaltyFixed": {
+        "title": "LoyaltyFixed",
+        "x-stoplight": {
+          "id": "r8i2lxuwj69a9"
+        },
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "FIXED",
+            "pattern": "FIXED"
+          },
+          "points": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "points"
+        ]
+      },
+      "LoyaltyProportionalOrderAmount": {
+        "title": "LoyaltyProportionalOrderAmount",
+        "x-stoplight": {
+          "id": "ba02f2bf0c553"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "ORDER_AMOUNT",
+            "pattern": "ORDER_AMOUNT"
+          },
+          "order": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "order"
+        ]
+      },
+      "LoyaltyProportionalOrderTotalAmount": {
+        "title": "LoyaltyProportionalOrderTotalAmount",
+        "x-stoplight": {
+          "id": "gjt5cp0reb3if"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "ORDER_TOTAL_AMOUNT",
+            "pattern": "ORDER_TOTAL_AMOUNT"
+          },
+          "order": {
+            "type": "object",
+            "required": [
+              "total_amount"
+            ],
+            "properties": {
+              "total_amount": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "order"
+        ]
+      },
+      "LoyaltyProportionalOrderMetadata": {
+        "title": "LoyaltyProportionalOrderMetadata",
+        "x-stoplight": {
+          "id": "cd8x9bvigsbux"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "ORDER_METADATA",
+            "pattern": "ORDER_METADATA"
+          },
+          "order": {
+            "type": "object",
+            "required": [
+              "metadata"
+            ],
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points",
+                  "property"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  },
+                  "property": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "order"
+        ]
+      },
+      "LoyaltyProportionalOrderItemsQuantity": {
+        "title": "LoyaltyProportionalOrderItemsQuantity",
+        "x-stoplight": {
+          "id": "zvh11dvch1wwe"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "ORDER_ITEMS_QUANTITY",
+            "pattern": "ORDER_ITEMS_QUANTITY"
+          },
+          "order_items": {
+            "type": "object",
+            "required": [
+              "quantity"
+            ],
+            "properties": {
+              "quantity": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points",
+                  "quantity",
+                  "id"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  },
+                  "quantity": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "order_items"
+        ]
+      },
+      "LoyaltyProportionalOrderItemsAmount": {
+        "title": "LoyaltyProportionalOrderItemsAmount",
+        "x-stoplight": {
+          "id": "0bnhmqmqx4hs0"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "ORDER_ITEMS_AMOUNT",
+            "pattern": "ORDER_ITEMS_AMOUNT"
+          },
+          "order_items": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points",
+                  "quantity",
+                  "id"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  },
+                  "quantity": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "order_items"
+        ]
+      },
+      "LoyaltyProportionalOrderItemsSubtotalAmount": {
+        "title": "LoyaltyProportionalOrderItemsSubtotalAmount",
+        "x-stoplight": {
+          "id": "b2adyarv9vp9c"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "ORDER_ITEMS_SUBTOTAL_AMOUNT",
+            "pattern": "ORDER_ITEMS_SUBTOTAL_AMOUNT"
+          },
+          "order_items": {
+            "type": "object",
+            "required": [
+              "subtotal_amount"
+            ],
+            "properties": {
+              "subtotal_amount": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points",
+                  "quantity",
+                  "id"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  },
+                  "quantity": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "order_items"
+        ]
+      },
+      "LoyaltyProportionalOrder": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderAmount"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderTotalAmount"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderMetadata"
+          }
+        ],
+        "title": ""
+      },
+      "LoyaltyProportionalOrderItems": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderItemsQuantity"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderItemsAmount"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderItemsSubtotalAmount"
+          }
+        ]
+      },
+      "LoyaltyProportionalCustomer": {
+        "title": "LoyaltyProportionalCustomer",
+        "x-stoplight": {
+          "id": "8fx7exsbq5tzq"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "CUSTOMER_METADATA",
+            "pattern": "CUSTOMER_METADATA"
+          },
+          "customer": {
+            "type": "object",
+            "required": [
+              "metadata"
+            ],
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points",
+                  "property"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  },
+                  "property": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "customer"
+        ]
+      },
+      "LoyaltyProportionalCustomEvent": {
+        "title": "LoyaltyProportionalCustomEvent",
+        "x-stoplight": {
+          "id": "9h5m2xpb8cccu"
+        },
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "default": "PROPORTIONAL",
+            "pattern": "PROPORTIONAL"
+          },
+          "calculation_type": {
+            "type": "string",
+            "default": "CUSTOM_EVENT_METADATA",
+            "pattern": "CUSTOM_EVENT_METADATA"
+          },
+          "custom_event": {
+            "type": "object",
+            "required": [
+              "metadata"
+            ],
+            "properties": {
+              "metadata": {
+                "type": "object",
+                "required": [
+                  "every",
+                  "points",
+                  "property"
+                ],
+                "properties": {
+                  "every": {
+                    "type": "integer"
+                  },
+                  "points": {
+                    "type": "number"
+                  },
+                  "property": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "calculation_type",
+          "custom_event"
+        ]
+      },
+      "LoyaltyProportional": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrder"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalOrderItems"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalCustomer"
+          },
+          {
+            "$ref": "#/components/schemas/LoyaltyProportionalCustomEvent"
+          }
+        ]
+      },
+      "LoyaltiesEarningRulesResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesResponseCommon"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "validation_rule_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "updated_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "active": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "updated_at",
+              "active"
+            ]
+          }
+        ]
+      },
+      "LoyaltiesEnableEarningRulesResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesResponseCommon"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "updated_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "active": {
+                "type": "boolean",
+                "default": true,
+                "readOnly": true
+              }
+            },
+            "required": [
+              "updated_at",
+              "active"
+            ]
+          }
+        ]
+      },
+      "LoyaltiesDisableEarningRulesResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesResponseCommon"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "updated_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "active": {
+                "type": "boolean",
+                "default": false,
+                "readOnly": true
+              }
+            },
+            "required": [
+              "updated_at",
+              "active"
+            ]
+          }
+        ]
+      },
+      "LoyaltiesUpdateEarningRuleResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesResponseCommon"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "validation_rule_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "updated_at",
+              "active"
+            ]
+          }
+        ]
+      },
+      "LoyaltiesCreateEarningRuleResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesResponseCommon"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "validation_rule_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "updated_at": {
+                "type": "null"
+              },
+              "active": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "updated_at",
+              "active"
+            ]
+          }
+        ]
+      },
+      "LoyaltiesListEarningRulesResponse": {
+        "title": "LoyaltiesListEarningRulesResponse",
+        "x-stoplight": {
+          "id": "9wr5op410qynz"
+        },
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "default": "list",
+            "pattern": "list"
+          },
+          "total": {
+            "type": "number",
+            "minimum": 0
+          },
+          "data_ref": {
+            "type": "string"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LoyaltiesEarningRulesResponse"
+            }
+          }
+        }
+      },
+      "LoyaltiesEarningRulesEvent": {
+        "anyOf": [
+          {
+            "default": "order.paid",
+            "pattern": "order.paid"
+          },
+          {
+            "default": "customer.segment.entered",
+            "pattern": "customer.segment.entered"
+          },
+          {
+            "default": "custom_event",
+            "pattern": "custom_event"
+          },
+          {
+            "default": "customer.loyalty.tier.upgraded",
+            "pattern": "customer.loyalty.tier.upgraded"
+          },
+          {
+            "default": "customer.loyalty.tier.downgraded",
+            "pattern": "customer.loyalty.tier.downgraded"
+          },
+          {
+            "default": "customer.loyalty.tier.prolonged",
+            "pattern": "customer.loyalty.tier.prolonged"
+          },
+          {
+            "default": "customer.loyalty.tier.joined",
+            "pattern": "customer.loyalty.tier.joined"
+          },
+          {
+            "default": "customer.loyalty.tier.left",
+            "pattern": "customer.loyalty.tier.left"
+          }
+        ],
+        "type": "string",
+        "title": ""
+      },
+      "LoyaltiesCreateEarningRule": {
+        "title": "LoyaltiesCreateEarningRule",
+        "x-stoplight": {
+          "id": "kfkww5k5ympid"
+        },
+        "type": "object",
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/LoyaltiesEarningRulesEvent"
+          },
+          "custom_event": {
+            "type": "object",
+            "properties": {
+              "schema_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_id"
+            ]
+          },
+          "validation_rule_id": {
+            "type": "string"
+          },
+          "loyalty": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LoyaltyFixed"
+              },
+              {
+                "$ref": "#/components/schemas/LoyaltyProportional"
+              }
+            ]
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "banner": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "banner"
+            ]
+          },
+          "loyalty_tier": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          "segment": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "expiration_date": {
+            "type": "string"
+          },
+          "validity_timeframe": {
+            "type": "object",
+            "properties": {
+              "duration": {
+                "type": "string"
+              },
+              "interval": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "duration",
+              "interval"
+            ]
+          },
+          "validity_day_of_week": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "loyalty"
+        ]
+      },
+      "LoyaltiesUpdateEarningRule": {
+        "title": "LoyaltiesUpdateEarningRule",
+        "x-stoplight": {
+          "id": "wa4fjq7mtq14s"
+        },
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "validation_rule_id": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "banner": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "banner"
+            ]
+          },
+          "loyalty": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LoyaltyFixed"
+              },
+              {
+                "$ref": "#/components/schemas/LoyaltyProportional"
+              }
+            ]
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "expiration_date": {
+            "type": "string"
+          },
+          "validity_timeframe": {
+            "type": "object",
+            "properties": {
+              "duration": {
+                "type": "string"
+              },
+              "interval": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "duration",
+              "interval"
+            ]
+          },
+          "validity_day_of_week": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "a_req_importCSV": {
         "type": "object",
         "title": "Import CSV file",
@@ -64581,7 +65599,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_res_list_earning_rules"
+                  "$ref": "#/components/schemas/LoyaltiesListEarningRulesResponse"
                 },
                 "examples": {
                   "Example": {
@@ -65131,7 +66149,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/8_req_create_earning_rules"
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LoyaltiesCreateEarningRule"
+                }
               },
               "examples": {
                 "Example": {
@@ -65652,7 +66673,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/8_obj_earning_rule_object"
+                    "$ref": "LoyaltiesCreateEarningRuleResponse"
                   }
                 },
                 "examples": {
@@ -66348,7 +67369,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_obj_earning_rule_object"
+                  "$ref": "#/components/schemas/LoyaltiesEarningRulesResponse"
                 },
                 "examples": {
                   "Custom Event": {
@@ -66626,7 +67647,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/8_req_update_earning_rule"
+                "$ref": "#/components/schemas/LoyaltiesUpdateEarningRule"
               },
               "examples": {
                 "Example": {
@@ -66669,7 +67690,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_obj_earning_rule_object"
+                  "$ref": "#/components/schemas/LoyaltiesUpdateEarningRuleResponse"
                 },
                 "examples": {
                   "Example": {
@@ -66814,7 +67835,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_obj_earning_rule_object_no_validation_rule"
+                  "$ref": "#/components/schemas/LoyaltiesEnableEarningRulesResponse"
                 },
                 "examples": {
                   "Example": {
@@ -66922,7 +67943,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/8_obj_earning_rule_object_no_validation_rule"
+                  "$ref": "#/components/schemas/LoyaltiesDisableEarningRulesResponse"
                 },
                 "examples": {
                   "Example": {


### PR DESCRIPTION
## 20230905 - Exports API

**New models**
- LoyaltiesEarningRulesResponseCommon
- LoyaltyFixed
- LoyaltyProportionalOrderAmount
- LoyaltyProportionalOrderTotalAmount
- LoyaltyProportionalOrderMetadata
- LoyaltyProportionalOrderItemsQuantity
- LoyaltyProportionalOrderItemsAmount
- LoyaltyProportionalOrderItemsSubtotalAmount
- LoyaltyProportionalOrder
- LoyaltyProportionalOrderItems
- LoyaltyProportionalCustomer
- LoyaltyProportionalCustomEvent
- LoyaltyProportional
- LoyaltiesEarningRulesResponse
- LoyaltiesEnableEarningRulesResponse
- LoyaltiesDisableEarningRulesResponse
- LoyaltiesUpdateEarningRuleResponse
- LoyaltiesCreateEarningRuleResponse
- LoyaltiesListEarningRulesResponse
- LoyaltiesEarningRulesEvent
- LoyaltiesCreateEarningRule
- LoyaltiesUpdateEarningRule

**Endpoint changes**
- /v1/loyalties/{campaignId}/earning-rules
  - GET
    - New response schema: `LoyaltiesListEarningRulesResponse` (old one: `8_res_list_earning_rules`)
    - POST
      - New request schema: `LoyaltiesCreateEarningRule` (old one: `8_req_create_earning_rules`)
      - New response schema: `LoyaltiesCreateEarningRuleResponse` (old one: `8_obj_earning_rule_object`)
- /v1/loyalties/{campaignId}/earning-rules/{earningRuleId}
  - GET
    - New response schema: `LoyaltiesEarningRulesResponse` (old one: `8_obj_earning_rule_object`)
  - PUT
    - New request schema: `LoyaltiesUpdateEarningRule` (old one: `8_req_update_earning_rule`)
    - New response schema: `LoyaltiesUpdateEarningRuleResponse` (old one: `8_obj_earning_rule_object`)
- /v1/loyalties/{campaignId}/earning-rules/{earningRuleId}/enable
  - POST
    - New response schema: `LoyaltiesEnableEarningRulesResponse` (old one: `8_obj_earning_rule_object_no_validation_rule`)
- /v1/loyalties/{campaignId}/earning-rules/{earningRuleId}/disable
    - POST
        - New response schema: `LoyaltiesDisableEarningRulesResponse` (old one: `8_obj_earning_rule_object_no_validation_rule`)