### PR TITLE
pz/types-012 - promotionsStacks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 20231012
+
+#### New schemas
+- PromotionsStacksListInCampaignResponseBody
+- PromotionsStacksListResponseBody
+- PromotionsStacksListRequestQuery
+- PromotionsStacksGetResponseBody
+- PromotionsStacksUpdateRequestBody
+- PromotionsStacksUpdateResponseBody
+- PromotionsStacksCreateInCampaignRequestBody
+- PromotionsStacksCreateInCampaignResponseBody
+- PromotionStackBase
+- PromotionStack
+
+- GET /v1/promotions/{campaignId}/stacks
+  - new response schema `PromotionsStacksListInCampaignResponseBody` (old `3_res_list_promotion_stacks`)
+- POST /v1/promotions/{campaignId}/stacks
+  - new request schema `PromotionsStacksCreateInCampaignRequestBody` (old `3_req_create_promotion_stack`)
+  - new response schema `PromotionsStacksCreateInCampaignResponseBody` (old `3_obj_promotion_stack_object`)
+- GET /v1/promotions/{campaignId}/stacks/{stackId}
+  - new response schema `PromotionsStacksGetResponseBody` (old `3_obj_promotion_stack_object`)
+- PUT /v1/promotions/{campaignId}/stacks/{stackId}
+  - new request schema `PromotionsStacksUpdateRequestBody` (old `3_req_create_promotion_stack`)
+  - new response schema `PromotionsStacksUpdateResponseBody` (old `3_obj_promotion_stack_object`)
+- GET /v1/promotions/stacks
+  - new response schema `PromotionsStacksListResponseBody` (old `3_res_list_promotion_stacks`)
 
 ## 20231009
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20231012
+## 20231012 - Promotions Stacks
 
 #### New schemas
 - PromotionsStacksListInCampaignResponseBody

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -39240,6 +39240,424 @@
           }
         }
       },
+      "PromotionsStacksListInCampaignResponseBody": {
+        "title": "Promotions Stacks List In Campaign Response Body",
+        "x-stoplight": {
+          "id": "4vg6isqaq6snd"
+        },
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ],
+            "description": "The type of object represented by JSON. This object stores information about promotion stacks in a dictionary."
+          },
+          "data_ref": {
+            "type": "string",
+            "enum": [
+              "data"
+            ],
+            "description": "Identifies the name of the attribute that contains the array of promotion stack objects."
+          },
+          "data": {
+            "type": "array",
+            "description": "Contains array of promotion stack objects.",
+            "items": {
+              "$ref": "#/components/schemas/PromotionStack"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total number of promotion stacks."
+          }
+        },
+        "required": [
+          "object",
+          "data_ref",
+          "data",
+          "total"
+        ]
+      },
+      "PromotionsStacksListResponseBody": {
+        "title": "Promotions Stacks List Response Body",
+        "x-stoplight": {
+          "id": "xulqc9a55rqq1"
+        },
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "list"
+            ],
+            "description": "The type of object represented by JSON. This object stores information about promotion stacks in a dictionary."
+          },
+          "data_ref": {
+            "type": "string",
+            "enum": [
+              "data"
+            ],
+            "description": "Identifies the name of the attribute that contains the array of promotion stack objects."
+          },
+          "data": {
+            "type": "array",
+            "description": "Contains array of promotion stack objects.",
+            "items": {
+              "$ref": "#/components/schemas/PromotionStack"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total number of promotion stacks."
+          }
+        },
+        "required": [
+          "object",
+          "data_ref",
+          "data",
+          "total"
+        ]
+      },
+      "PromotionsStacksListRequestQuery": {
+        "title": "Promotions Stacks List Request Query",
+        "x-stoplight": {
+          "id": "tlxava3tsdz67"
+        },
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "multipleOf": 100,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100 items."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Which page of results to return."
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "created_at",
+              "-created_at",
+              "updated_at",
+              "-updated_at",
+              "name",
+              "-name"
+            ],
+            "description": "Sorts the results using one of the filtering options, where the dash - preceding a sorting option means sorting in a descending order."
+          },
+          "created_at": {
+            "type": "object",
+            "description": "A filter on the list based on the object created_at field. The value is a dictionary with the following options: before, after. A date value must be presented in ISO 8601 format (2016-11-16T14:14:31Z or 2016-11-16). An example: [created_at][before]=2017-09-08T13:52:18.227Z",
+            "properties": {
+              "before": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time before the voucher was created in ISO 8601 format."
+              },
+              "after": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time after the voucher was created in ISO 8601 format."
+              }
+            }
+          },
+          "updated_at": {
+            "type": "object",
+            "description": "A filter on the list based on the object updated_at field. The value is a dictionary with the following options: before, after. A date value must be presented in ISO 8601 format (2016-11-16T14:14:31Z or 2016-11-16). An example: [updated_at][before]=2017-09-08T13:52:18.227Z",
+            "properties": {
+              "before": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time before the voucher was updated in ISO 8601 format."
+              },
+              "after": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time after the voucher was updated in ISO 8601 format."
+              }
+            }
+          }
+        }
+      },
+      "PromotionsStacksGetResponseBody": {
+        "$ref": "#/components/schemas/PromotionStack",
+        "x-stoplight": {
+          "id": "yo10kdxqlepqn"
+        },
+        "title": "Promotions Stacks Get Response Body"
+      },
+      "PromotionsStacksUpdateRequestBody": {
+        "title": "Promotions Stacks Update Request Body",
+        "x-stoplight": {
+          "id": "8jlymzh3ddocw"
+        },
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Promotion stack name."
+          },
+          "tiers": {
+            "type": "object",
+            "description": "Contains the tier configuration.",
+            "properties": {
+              "ids": {
+                "type": "array",
+                "description": "Contains the list of tiers in a pre-defined sequence.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "hierarchy_mode": {
+                "type": "string",
+                "enum": [
+                  "MANUAL"
+                ],
+                "description": "Category hierarchy."
+              }
+            }
+          },
+          "category_id": {
+            "type": "string",
+            "description": "Promotion stack category ID."
+          }
+        }
+      },
+      "PromotionsStacksUpdateResponseBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromotionStackBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique promotion stack ID."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion stack was created in ISO 8601 format."
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion stack was updated in ISO 8601 format."
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion stack's parent campaign's unique ID."
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "promotion_stack"
+                ],
+                "description": "The type of object represented by JSON. "
+              },
+              "category_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Promotion stack category ID."
+              },
+              "categories": {
+                "type": "array",
+                "description": "Details about the category assigned to the promotion stack.",
+                "items": {
+                  "$ref": "#/components/schemas/PromotionStackBase"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "created_at",
+              "updated_at",
+              "campaign_id",
+              "object",
+              "category_id",
+              "categories"
+            ]
+          }
+        ]
+      },
+      "PromotionsStacksCreateInCampaignRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromotionStackBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "category_id": {
+                "type": "string",
+                "description": "Promotion stack category ID."
+              }
+            }
+          }
+        ]
+      },
+      "PromotionsStacksCreateInCampaignResponseBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromotionStackBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique promotion stack ID."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion stack was created in ISO 8601 format."
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion stack's parent campaign's unique ID."
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "promotion_stack"
+                ],
+                "description": "The type of object represented by JSON."
+              },
+              "category_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Promotion stack category ID."
+              },
+              "categories": {
+                "type": "array",
+                "description": "Details about the category assigned to the promotion stack.",
+                "items": {
+                  "$ref": "#/components/schemas/PromotionStackBase"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "created_at",
+              "campaign_id",
+              "object",
+              "category_id",
+              "categories"
+            ]
+          }
+        ]
+      },
+      "PromotionStackBase": {
+        "title": "Promotion Stack Base",
+        "x-stoplight": {
+          "id": "m7vtpwtnuvjpe"
+        },
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Promotion stack name."
+          },
+          "tiers": {
+            "type": "object",
+            "required": [
+              "ids"
+            ],
+            "description": "Contains the tier configuration.",
+            "properties": {
+              "ids": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Contains the list of tiers in a pre-defined sequence.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "hierarchy_mode": {
+                "type": "string",
+                "enum": [
+                  "MANUAL"
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "name",
+          "tiers"
+        ]
+      },
+      "PromotionStack": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromotionStackBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique promotion stack ID."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion stack was created in ISO 8601 format."
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion stack was updated in ISO 8601 format."
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion stack's parent campaign's unique ID."
+              },
+              "object": {
+                "type": "string",
+                "enum": [
+                  "promotion_stack"
+                ],
+                "description": "The type of object represented by JSON. "
+              },
+              "category_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Promotion stack category ID."
+              },
+              "categories": {
+                "type": "array",
+                "description": "Details about the category assigned to the promotion stack.",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "created_at",
+              "campaign_id",
+              "object",
+              "category_id",
+              "categories"
+            ]
+          }
+        ]
+      },
       "LoyaltiesGetEarningRuleResponseBody": {
         "allOf": [
           {
@@ -51998,7 +52416,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/3_res_list_promotion_stacks"
+                  "$ref": "#/components/schemas/PromotionsStacksListResponseBody"
                 },
                 "examples": {
                   "Example": {
@@ -52184,7 +52602,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/3_res_list_promotion_stacks"
+                  "$ref": "#/components/schemas/PromotionsStacksListInCampaignResponseBody"
                 },
                 "examples": {
                   "Example": {
@@ -52249,7 +52667,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/3_req_create_promotion_stack"
+                "$ref": "#/components/schemas/PromotionsStacksCreateInCampaignRequestBody"
               },
               "examples": {
                 "Example": {
@@ -52275,7 +52693,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/3_obj_promotion_stack_object"
+                  "$ref": "#/components/schemas/PromotionsStacksCreateInCampaignResponseBody"
                 },
                 "examples": {
                   "Example": {
@@ -52379,7 +52797,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/3_obj_promotion_stack_object"
+                  "$ref": "#/components/schemas/PromotionsStacksGetResponseBody"
                 },
                 "examples": {
                   "Example": {
@@ -52457,7 +52875,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/3_req_create_promotion_stack"
+                "$ref": "#/components/schemas/PromotionsStacksUpdateRequestBody"
               },
               "examples": {
                 "Example": {
@@ -52482,7 +52900,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/3_obj_promotion_stack_object"
+                  "$ref": "#/components/schemas/PromotionsStacksUpdateResponseBody"
                 },
                 "examples": {
                   "Example": {


### PR DESCRIPTION
## 20231012 - Promotions Stacks

#### New schemas
- PromotionsStacksListInCampaignResponseBody
- PromotionsStacksListResponseBody
- PromotionsStacksListRequestQuery
- PromotionsStacksGetResponseBody
- PromotionsStacksUpdateRequestBody
- PromotionsStacksUpdateResponseBody
- PromotionsStacksCreateInCampaignRequestBody
- PromotionsStacksCreateInCampaignResponseBody
- PromotionStackBase
- PromotionStack

- GET /v1/promotions/{campaignId}/stacks
  - new response schema `PromotionsStacksListInCampaignResponseBody` (old `3_res_list_promotion_stacks`)
- POST /v1/promotions/{campaignId}/stacks
  - new request schema `PromotionsStacksCreateInCampaignRequestBody` (old `3_req_create_promotion_stack`)
  - new response schema `PromotionsStacksCreateInCampaignResponseBody` (old `3_obj_promotion_stack_object`)
- GET /v1/promotions/{campaignId}/stacks/{stackId}
  - new response schema `PromotionsStacksGetResponseBody` (old `3_obj_promotion_stack_object`)
- PUT /v1/promotions/{campaignId}/stacks/{stackId}
  - new request schema `PromotionsStacksUpdateRequestBody` (old `3_req_create_promotion_stack`)
  - new response schema `PromotionsStacksUpdateResponseBody` (old `3_obj_promotion_stack_object`)
- GET /v1/promotions/stacks
  - new response schema `PromotionsStacksListResponseBody` (old `3_res_list_promotion_stacks`)


https://docs.voucherify.io/v2018-08-01-piotr-490/reference/create-promotion-stack