### PR TITLE
001 - Voucher transactions, unification of domain types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 20231025 - Vouchers
+
+**Changes in models**
+- Removed `gift_card_transaction_identity`, `gift_card_transaction_created` - these types were combined into the `gift_card_transaction_base` model
+- Fixed the enum defined for `fields` property in `voucher_transactions_export_parameters` and `voucher_transactions_filters` models
+
 ## 20230924
 
 - Updated `docs/guides/getting_started/Quickstart.md`

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -3800,13 +3800,7 @@
               "title": "Redemption",
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/gift_card_transaction_identity"
-                },
-                {
                   "$ref": "#/components/schemas/gift_card_transaction_base"
-                },
-                {
-                  "$ref": "#/components/schemas/gift_card_transaction_created"
                 },
                 {
                   "$ref": "#/components/schemas/gift_card_transaction_redemption_details"
@@ -3817,13 +3811,7 @@
               "title": "Refund",
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/gift_card_transaction_identity"
-                },
-                {
                   "$ref": "#/components/schemas/gift_card_transaction_base"
-                },
-                {
-                  "$ref": "#/components/schemas/gift_card_transaction_created"
                 },
                 {
                   "$ref": "#/components/schemas/gift_card_transaction_refund_details"
@@ -3834,13 +3822,7 @@
               "title": "Addition",
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/gift_card_transaction_identity"
-                },
-                {
                   "$ref": "#/components/schemas/gift_card_transaction_base"
-                },
-                {
-                  "$ref": "#/components/schemas/gift_card_transaction_created"
                 },
                 {
                   "$ref": "#/components/schemas/gift_card_transaction_addition_details"
@@ -3851,13 +3833,7 @@
               "title": "Removal",
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/gift_card_transaction_identity"
-                },
-                {
                   "$ref": "#/components/schemas/gift_card_transaction_base"
-                },
-                {
-                  "$ref": "#/components/schemas/gift_card_transaction_created"
                 },
                 {
                   "$ref": "#/components/schemas/gift_card_transaction_removal_details"
@@ -3866,8 +3842,9 @@
             }
           ]
       },
-      "gift_card_transaction_identity": {
+      "gift_card_transaction_base": {
         "type": "object",
+        "title": "Gift Card Transaction Base",
         "properties": {
           "id": {
             "type": "string",
@@ -3880,18 +3857,7 @@
               "null"
             ],
             "description": "The merchant’s transaction ID if it is different from the Voucherify transaction ID. It is really useful in case of an integration between multiple systems. It can be a transaction ID from a CRM system, database or 3rd-party service. In case of a redemption, this value is `null`."
-          }
-        },
-        "required": [
-          "id",
-          "source_id"
-        ],
-        "title": "Gift Card Transaction Identity"
-      },
-      "gift_card_transaction_base": {
-        "type": "object",
-        "title": "Gift Card Transaction Base",
-        "properties": {
+          },
           "voucher_id": {
             "type": "string",
             "description": "Unique voucher ID.",
@@ -3918,19 +3884,7 @@
               "null"
             ],
             "description": "This field is `null` in the case of gift voucher transactions."
-          }
-        },
-        "required": [
-          "voucher_id",
-          "campaign_id",
-          "reason",
-          "related_transaction_id"
-        ]
-      },
-      "gift_card_transaction_created": {
-        "type": "object",
-        "title": "Gift Card Transaction Response Data",
-        "properties": {
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -3939,6 +3893,12 @@
           }
         },
         "required": [
+          "id",
+          "source_id",
+          "voucher_id",
+          "campaign_id",
+          "reason",
+          "related_transaction_id",
           "created_at"
         ]
       },
@@ -4469,7 +4429,18 @@
           "fields": {
             "type": "array",
             "enum": [
-              "id,type,source_id,reason,balance,amount,created_at,voucher_id,campaign_id,source,details,related_transaction_id"
+              "id",
+              "type",
+              "source_id",
+              "reason",
+              "balance",
+              "amount",
+              "created_at",
+              "voucher_id",
+              "campaign_id",
+              "source",
+              "details",
+              "related_transaction_id"
             ],
             "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file. The array can be a combination of any of the following available fields:\n\n| **Field** | **Definition** | **Example Export** |\n|:---|:---|:---|\n| id | Unique transaction ID. | vtx_0cb7811f1c07765800 |\n| type | Transaction type. | - `CREDITS_REMOVAL` <br> - `CREDITS_ADDITION` <br> - `CREDITS_REFUND` <br> - `CREDITS_REDEMPTION` <br> - `POINTS_ACCRUAL` <br> - `POINTS_CANCELLATION` <br> - `POINTS_REDEMPTION`<br> - `POINTS_REFUND`<br> - `POINTS_ADDITION`<br> - `POINTS_REMOVAL`<br> - `POINTS_EXPIRATION`<br> - `POINTS_TRANSFER_IN`<br> - `POINTS_TRANSFER_OUT` |\n| source_id | Unique transaction source ID. | 8638 |\n| reason | Contains the reason for the transaction if one was included originally. |  |\n| balance | The gift card or loyalty card balance after the transaction. |  |\n| amount | The amount of gift card or loyalty card credits being allocated during the transaction. This value can either be negative or positive depending on the nature of the transaction. |  |\n| created_at | Timestamp in ISO 8601 format representing the date and time when the transaction was created. | 2022-03-09T09:16:32.521Z  |\n| voucher_id | Unique Voucher ID. | v_dky7ksKfPX50Wb2Bxvcoeb1xT20b6tcp |\n| campaign_id | Parent campaign ID. | camp_FNYR4jhqZBM9xTptxDGgeNBV |\n| source|  Channel through which the transaction was initiated. | API |\n| details | More detailed information stored in the form of a JSON. | Provides more details related to the transaction in the form of an object. |",
             "items": {
@@ -30197,7 +30168,18 @@
           "fields": {
             "type": "array",
             "enum": [
-              "id,type,source_id,reason,balance,amount,created_at,voucher_id,campaign_id,source,details,related_transaction_id"
+              "id",
+              "type",
+              "source_id",
+              "reason",
+              "balance",
+              "amount",
+              "created_at",
+              "voucher_id",
+              "campaign_id",
+              "source",
+              "details",
+              "related_transaction_id"
             ],
             "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file. The array can be a combination of any of the following available fields:\n\n| **Field** | **Definition** | **Example Export** |\n|:---|:---|:---|\n| id | Unique transaction ID. | vtx_0cb7811f1c07765800 |\n| type | Transaction type. | - `CREDITS_REMOVAL` <br> - `CREDITS_ADDITION` <br> - `CREDITS_REFUND` <br> - `CREDITS_REDEMPTION` <br> - `POINTS_ACCRUAL` <br> - `POINTS_CANCELLATION` <br> - `POINTS_REDEMPTION`<br> - `POINTS_REFUND`<br> - `POINTS_ADDITION`<br> - `POINTS_REMOVAL`<br> - `POINTS_EXPIRATION`<br> - `POINTS_TRANSFER_IN`<br> - `POINTS_TRANSFER_OUT` |\n| source_id | Unique transaction source ID. | 8638 |\n| reason | Contains the reason for the transaction if one was included originally. |  |\n| balance | The gift card or loyalty card balance after the transaction. |  |\n| amount | The amount of gift card or loyalty card credits being allocated during the transaction. This value can either be negative or positive depending on the nature of the transaction. |  |\n| created_at | Timestamp in ISO 8601 format representing the date and time when the transaction was created. | 2022-03-09T09:16:32.521Z  |\n| voucher_id | Unique Voucher ID. | v_dky7ksKfPX50Wb2Bxvcoeb1xT20b6tcp |\n| campaign_id | Parent campaign ID. | camp_FNYR4jhqZBM9xTptxDGgeNBV |\n| source|  Channel through which the transaction was initiated. | API |\n| details | More detailed information stored in the form of a JSON. | Provides more details related to the transaction in the form of an object. |",
             "items": {


### PR DESCRIPTION
## 20231025 - Vouchers

**Changes in models**
- Removed `gift_card_transaction_identity`, `gift_card_transaction_created` - these types were combined into the `gift_card_transaction_base` model
- Fixed the enum defined for `fields` property in `voucher_transactions_export_parameters` and `voucher_transactions_filters` models


Methods to be verified in readme.io: https://docs.voucherify.io/v2018-08-01-wk-509/reference/list-voucher-transactions
https://docs.voucherify.io/v2018-08-01-wk-509/reference/export-voucher-transactions