### PR TITLE
Pz/fix list member rewards

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20231027 - GET List Member Rewards
+
+Added `required` and `description` attributes.
+
 ## 20231026 - Stackable API
 
 **Added schemas**

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -39433,29 +39433,35 @@
         "properties": {
           "object": {
             "type": "string",
+            "description": "The type of object represented by JSON.",
             "enum": [
               "list"
             ]
           },
           "data_ref": {
             "type": "string",
+            "description": "Identifies the name of the attribute that contains the array of loyalty reward objects.",
             "enum": [
               "data"
             ]
           },
           "data": {
             "type": "array",
+            "description": "Contains array of loyalty reward objects.",
             "items": {
               "type": "object",
               "properties": {
                 "reward": {
+                  "description": "This is an object representing a reward.",
                   "$ref": "#/components/schemas/reward"
                 },
                 "assignment": {
+                  "description": "This is an object representing a reward assignment.",
                   "$ref": "#/components/schemas/reward_assignment"
                 },
                 "object": {
                   "type": "string",
+                  "description": "The type of object represented by JSON.",
                   "enum": [
                     "loyalty_reward"
                   ]
@@ -39465,9 +39471,16 @@
           },
           "total": {
             "type": "integer",
+            "description": "Total number of loyalty reward objects.",
             "minimum": 0
           }
-        }
+        },
+        "required": [
+          "object",
+          "data_ref",
+          "data",
+          "total"
+        ]
       },
       "LoyaltiesListLoyaltyTierEarningRulesRequestQuery": {
         "title": "LoyaltiesListLoyaltyTierEarningRulesRequestQuery",


### PR DESCRIPTION
## 20231027 - GET List Member Rewards

Added `required` and `description` attributes in `LoyaltiesListMemberRewardsResponseBody` schema.