### PR TITLE
Pz/script to remove unused schema elements

### DIFF
--- a/scripts/remove-stoplight-tags-from-openapi.ts
+++ b/scripts/remove-stoplight-tags-from-openapi.ts
@@ -1,31 +1,48 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from "fs/promises";
+import path from "path";
 
 function isObject(value) {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      !Array.isArray(value)
-    );
-  }
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-const removeStoplightTag = (node: object): object => {
-    delete node['x-stoplight'];
-    for(const attr in node){
-        if(isObject(node[attr])){
-            removeStoplightTag(node[attr])
-        }
+const removeKey = (node: object, key: string): object => {
+  delete node[key];
+  for (const attr in node) {
+    if (isObject(node[attr])) {
+      removeKey(node[attr], key);
     }
-    return node;
-}
+  }
+  return node;
+};
 
-const main = async() => {
-    const openApiPath = path.join(__dirname, '../reference/OpenAPI.json');
-    const openAPIContent = JSON.parse((await fs.readFile(openApiPath)).toString())
+const main = async () => {
+  const openApiPath = path.join(__dirname, "../reference/OpenAPI.json");
+  const openAPIContent = JSON.parse(
+    (await fs.readFile(openApiPath)).toString()
+  );
 
-    removeStoplightTag(openAPIContent)
+  removeKey(openAPIContent, "x-stoplight");
 
-    await fs.writeFile(openApiPath, JSON.stringify(openAPIContent, null, 2) )
-}
+  //openAPIContent.components.schemas =
+  Object.fromEntries(
+    Object.entries(openAPIContent.components.schemas)
+      .map((entry) => {
+        const [name, object] = entry;
+        delete object["x-tags"];
+        if ((object as any).type === "object") {
+          delete object["examples"];
+          delete object["example"];
+        }
+        return [name, object];
+      })
+      .sort(
+        (a: [name: string, schema: any], b: [name: string, schema: any]) => {
+          return a[0].localeCompare(b[0]);
+        }
+      )
+  );
 
-main()
+  await fs.writeFile(openApiPath, JSON.stringify(openAPIContent, null, 2));
+};
+
+main();


### PR DESCRIPTION
Added some logic to scripts/remove-stoplight-tags-from-openapi.ts
Now schemas will not have x-tag and example keys after you run the script