### PR TITLE
Schema naming fix

### DIFF
--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -1023,7 +1023,7 @@
             "description": "This is an object containing information about the referrer.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/ReferrerRequest"
+                "$ref": "#/components/schemas/Referrer"
               }
             ]
           },
@@ -1295,7 +1295,7 @@
               "referrer": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/ReferrerResponse"
+                    "$ref": "#/components/schemas/ReferrerWithSummaryLoyaltyReferrals"
                   },
                   {
                     "$ref": "#/components/schemas/ReferrerId"
@@ -1511,7 +1511,7 @@
                 "description": "This is an ojbect containing information about the referrer.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/ReferrerRequest"
+                    "$ref": "#/components/schemas/Referrer"
                   }
                 ]
               },
@@ -1634,7 +1634,7 @@
                 "description": "This is an ojbect containing information about the referrer.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/ReferrerRequest"
+                    "$ref": "#/components/schemas/Referrer"
                   }
                 ]
               },
@@ -1701,16 +1701,16 @@
           "reward"
         ]
       },
-      "ReferrerRequest": {
-        "title": "Referrer Request",
+      "Referrer": {
+        "title": "Referrer",
         "allOf": [
           {
             "$ref": "#/components/schemas/Customer"
           }
         ]
       },
-      "ReferrerResponse": {
-        "title": "Referrer Response",
+      "ReferrerWithSummaryLoyaltyReferrals": {
+        "title": "Referrer With Summary Loyalty Referrals",
         "allOf": [
           {
             "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
@@ -26658,167 +26658,59 @@
           }
         }
       },
-      "ValidationRuleResponse": {
-        "title": "Validation Rule Response",
-        "type": "object",
-        "description": "This is an object representing a response validation rule.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "val_eR1c41hu0vUU",
-            "description": "Unique validation rule ID."
+      "ValidationRule": {
+        "title": "Validation Rule",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ValidationRuleBase"
           },
-          "name": {
-            "type": "string",
-            "description": "Custom, unique name for set of validation rules.",
-            "example": "Business Validation Rule"
-          },
-          "rules": {
-            "$ref": "#/components/schemas/ValidationRuleRules"
-          },
-          "error": {
+          {
+            "title": "Validation Rule",
             "type": "object",
-            "description": "Contains the error message returned from API when validation / redemption fails to meet requirements of defined rules.",
+            "description": "This is an object representing a response validation rule.",
             "properties": {
-              "message": {
+              "id": {
                 "type": "string",
-                "description": "The error message returned from API when validation / redemption fails to meet requirements of defined rules."
-              }
-            }
-          },
-          "applicable_to": {
-            "type": "object",
-            "nullable": true,
-            "properties": {
-              "excluded": {
-                "type": "array",
-                "description": "Defines which items are excluded from a discount.",
-                "items": {
-                  "$ref": "#/components/schemas/ApplicableTo"
-                }
+                "example": "val_eR1c41hu0vUU",
+                "description": "Unique validation rule ID."
               },
-              "included": {
-                "type": "array",
-                "description": "Defines which items are included in a discount.",
-                "items": {
-                  "$ref": "#/components/schemas/ApplicableTo"
-                }
+              "created_at": {
+                "type": "string",
+                "example": "2022-03-23T07:44:00.444Z",
+                "description": "Timestamp representing the date and time when the validation rule was created in ISO 8601 format.",
+                "format": "date-time"
               },
-              "included_all": {
-                "type": "boolean",
-                "description": "Indicates whether all items are included in the discount."
+              "updated_at": {
+                "type": "string",
+                "example": "2022-04-26T08:35:54.960Z",
+                "description": "Timestamp representing the date and time when the validation rule was updated in ISO 8601 format.",
+                "format": "date-time"
+              },
+              "assignments_count": {
+                "description": "The number of instances the validation rule has been assigned to different types of redeemables.",
+                "type": "integer"
+              },
+              "object": {
+                "type": "string",
+                "default": "validation_rules",
+                "description": "The type of object represented by JSON. This object stores information about the validation rule."
               }
-            }
-          },
-          "created_at": {
-            "type": "string",
-            "example": "2022-03-23T07:44:00.444Z",
-            "description": "Timestamp representing the date and time when the validation rule was created in ISO 8601 format.",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "example": "2022-04-26T08:35:54.960Z",
-            "description": "Timestamp representing the date and time when the validation rule was updated in ISO 8601 format.",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "expression",
-              "basic",
-              "advanced",
-              "complex"
-            ],
-            "description": "Type of validation rule."
-          },
-          "context_type": {
-            "type": "string",
-            "default": "global",
-            "enum": [
-              "earning_rule.order.paid",
-              "earning_rule.custom_event",
-              "earning_rule.customer.segment.entered",
-              "earning_rule.customer.tier.joined",
-              "earning_rule.customer.tier.left",
-              "earning_rule.customer.tier.upgraded",
-              "earning_rule.customer.tier.downgraded",
-              "earning_rule.customer.tier.prolonged",
-              "campaign.discount_coupons",
-              "campaign.discount_coupons.discount.apply_to_order",
-              "campaign.discount_coupons.discount.apply_to_items",
-              "campaign.discount_coupons.discount.apply_to_items_proportionally",
-              "campaign.discount_coupons.discount.apply_to_items_proportionally_by_quantity",
-              "campaign.discount_coupons.discount.apply_to_items_by_quantity",
-              "campaign.discount_coupons.discount.fixed.apply_to_items",
-              "campaign.discount_coupons.discount.percent.apply_to_items",
-              "campaign.gift_vouchers",
-              "campaign.gift_vouchers.gift.apply_to_order",
-              "campaign.gift_vouchers.gift.apply_to_items",
-              "campaign.referral_program",
-              "campaign.referral_program.discount.apply_to_order",
-              "campaign.referral_program.discount.apply_to_items",
-              "campaign.referral_program.discount.apply_to_items_proportionally",
-              "campaign.referral_program.discount.apply_to_items_proportionally_by_quantity",
-              "campaign.referral_program.discount.apply_to_items_by_quantity",
-              "campaign.referral_program.discount.fixed.apply_to_items",
-              "campaign.referral_program.discount.percent.apply_to_items",
-              "campaign.promotion",
-              "campaign.promotion.discount.apply_to_order",
-              "campaign.promotion.discount.apply_to_items",
-              "campaign.promotion.discount.apply_to_items_proportionally",
-              "campaign.promotion.discount.apply_to_items_proportionally_by_quantity",
-              "campaign.promotion.discount.apply_to_items_by_quantity",
-              "campaign.promotion.discount.fixed.apply_to_items",
-              "campaign.promotion.discount.percent.apply_to_items",
-              "campaign.loyalty_program",
-              "campaign.lucky_draw",
-              "voucher.discount_voucher",
-              "voucher.discount_voucher.discount.apply_to_order",
-              "voucher.discount_voucher.discount.apply_to_items",
-              "voucher.discount_voucher.discount.apply_to_items_proportionally",
-              "voucher.discount_voucher.discount.apply_to_items_proportionally_by_quantity",
-              "voucher.discount_voucher.discount.apply_to_items_by_quantity",
-              "voucher.discount_voucher.discount.fixed.apply_to_items",
-              "voucher.discount_voucher.discount.percent.apply_to_items",
-              "voucher.gift_voucher",
-              "voucher.gift_voucher.gift.apply_to_order",
-              "voucher.gift_voucher.gift.apply_to_items",
-              "voucher.loyalty_card",
-              "voucher.lucky_draw_code",
-              "distribution.custom_event",
-              "distribution.order.paid",
-              "distribution.order.created",
-              "distribution.order.canceled",
-              "distribution.order.updated",
-              "reward_assignment.pay_with_points",
-              "global"
-            ],
-            "description": "Validation rule context type.  \n\n| **Context Type** | **Definition** |\n|:---|:---|\n| earning_rule.order.paid |  |\n| earning_rule.custom_event |  |\n| earning_rule.customer.segment.entered |  |\n| campaign.discount_coupons |  |\n| campaign.discount_coupons.discount.apply_to_order |  |\n| campaign.discount_coupons.discount.apply_to_items |  |\n| campaign.discount_coupons.discount.apply_to_items_proportionally |  |\n| campaign.discount_coupons.discount.apply_to_items_proportionally_by_quantity |  |\n| campaign.discount_coupons.discount.fixed.apply_to_items |  |\n| campaign.gift_vouchers |  |\n| campaign.gift_vouchers.gift.apply_to_order |  |\n| campaign.gift_vouchers.gift.apply_to_items |  |\n| campaign.referral_program |  |\n| campaign.referral_program.discount.apply_to_order |  |\n| campaign.referral_program.discount.apply_to_items |  |\n| campaign.referral_program.discount.apply_to_items_proportionally |  |\n| campaign.referral_program.discount.apply_to_items_proportionally_by_quantity |  |\n| campaign.referral_program.discount.fixed.apply_to_items |  |\n| campaign.promotion |  |\n| campaign.promotion.discount.apply_to_order |  |\n| campaign.promotion.discount.apply_to_items |  |\n| campaign.promotion.discount.apply_to_items_proportionally |  |\n| campaign.promotion.discount.apply_to_items_proportionally_by_quantity |  |\n| campaign.promotion.discount.fixed.apply_to_items |  |\n| campaign.loyalty_program |  |\n| campaign.lucky_draw |  |\n| voucher.discount_voucher |  |\n| voucher.discount_voucher.discount.apply_to_order |  |\n| voucher.discount_voucher.discount.apply_to_items |  |\n| voucher.discount_voucher.discount.apply_to_items_proportionally |  |\n| voucher.discount_voucher.discount.apply_to_items_proportionally_by_quantity |  |\n| voucher.discount_voucher.discount.fixed.apply_to_items |  |\n| voucher.gift_voucher |  |\n| voucher.gift_voucher.gift.apply_to_order |  |\n| voucher.gift_voucher.gift.apply_to_items |  |\n| voucher.loyalty_card |  |\n| voucher.lucky_draw_code |  |\n| distribution.custom_event |  |\n| reward_assignment.pay_with_points |  |\n| global |  |"
-          },
-          "assignments_count": {
-            "description": "The number of instances the validation rule has been assigned to different types of redeemables.",
-            "type": "integer"
-          },
-          "object": {
-            "type": "string",
-            "default": "validation_rules",
-            "description": "The type of object represented by JSON. This object stores information about the validation rule."
+            },
+            "required": [
+              "id",
+              "name",
+              "rules",
+              "applicable_to",
+              "created_at",
+              "type",
+              "context_type",
+              "object"
+            ]
           }
-        },
-        "required": [
-          "id",
-          "name",
-          "rules",
-          "applicable_to",
-          "created_at",
-          "type",
-          "context_type",
-          "object"
         ]
       },
-      "ValidationRuleRequest": {
-        "title": "Validation Rule Request",
+      "ValidationRuleBase": {
+        "title": "Validation Rule Base",
         "type": "object",
         "description": "This is an object representing a request validation rule.",
         "properties": {
@@ -26946,7 +26838,7 @@
         "description": "Response body schema for **POST** `/validation-rules`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ValidationRuleResponse"
+            "$ref": "#/components/schemas/ValidationRule"
           }
         ]
       },
@@ -26956,7 +26848,7 @@
         "description": "Response body schema for **GET** `/validation-rules/{validationRuleId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ValidationRuleResponse"
+            "$ref": "#/components/schemas/ValidationRule"
           }
         ]
       },
@@ -26966,7 +26858,7 @@
         "description": "Response body schema for **PUT** `/validation-rules/{validationRuleId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ValidationRuleResponse"
+            "$ref": "#/components/schemas/ValidationRule"
           }
         ]
       },
@@ -26975,7 +26867,7 @@
         "description": "Request body schema for **POST** `/validation-rules`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ValidationRuleRequest"
+            "$ref": "#/components/schemas/ValidationRuleBase"
           },
           {
             "type": "object",
@@ -26990,7 +26882,7 @@
         "description": "Response body schema for **PUT** `/validation-rules/{validationRuleId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ValidationRuleRequest"
+            "$ref": "#/components/schemas/ValidationRuleBase"
           }
         ]
       },
@@ -27013,7 +26905,7 @@
             "type": "array",
             "description": "An array of validation rules.",
             "items": {
-              "$ref": "#/components/schemas/ValidationRuleResponse"
+              "$ref": "#/components/schemas/ValidationRule"
             }
           },
           "total": {
@@ -27426,7 +27318,7 @@
             "description": "A simple customer object",
             "allOf": [
               {
-                "$ref": "#/components/schemas/SimpleCustomerResponse"
+                "$ref": "#/components/schemas/SimpleCustomerRequiredObjectType"
               }
             ]
           },
@@ -27869,7 +27761,7 @@
             "description": "A simple customer object",
             "allOf": [
               {
-                "$ref": "#/components/schemas/SimpleCustomerResponse"
+                "$ref": "#/components/schemas/SimpleCustomerRequiredObjectType"
               }
             ]
           },
@@ -37076,10 +36968,10 @@
           "filter"
         ]
       },
-      "SimpleCustomerResponse": {
+      "SimpleCustomerRequiredObjectType": {
         "type": "object",
         "description": "This is an object representing a customer with limited properties used in Event Tracking endpoints.",
-        "title": "Customer Object",
+        "title": "Customer Object Required Object Type",
         "properties": {
           "id": {
             "type": "string",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -973,8 +973,8 @@
           }
         ]
       },
-      "OrderRequestBase": {
-        "title": "Order Request Base",
+      "OrderBase": {
+        "title": "Order Base",
         "type": "object",
         "properties": {
           "status": {
@@ -1003,14 +1003,14 @@
             "type": "array",
             "description": "Array of items applied to the order.",
             "items": {
-              "$ref": "#/components/schemas/OrderItemRequest"
+              "$ref": "#/components/schemas/OrderItem"
             }
           },
           "customer": {
             "description": "This is an object containing information about the customer.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -1129,8 +1129,8 @@
           "object"
         ]
       },
-      "OrderRequest": {
-        "title": "Order Request",
+      "Order": {
+        "title": "Order",
         "allOf": [
           {
             "title": "Order Ids",
@@ -1147,11 +1147,11 @@
             }
           },
           {
-            "$ref": "#/components/schemas/OrderRequestBase"
+            "$ref": "#/components/schemas/OrderBase"
           }
         ]
       },
-      "OrderResponseBase": {
+      "OrderCalculatedBase": {
         "title": "Order Response Base",
         "type": "object",
         "additionalProperties": false,
@@ -1229,7 +1229,7 @@
             "type": "array",
             "description": "Array of items applied to the order.",
             "items": {
-              "$ref": "#/components/schemas/OrderItemResponse"
+              "$ref": "#/components/schemas/OrderItemCalculated"
             }
           },
           "metadata": {
@@ -1270,14 +1270,14 @@
           "object"
         ]
       },
-      "OrderResponse": {
-        "title": "Order Response",
+      "OrderCalculated": {
+        "title": "Order Calculated",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderResponseBase"
+            "$ref": "#/components/schemas/OrderCalculatedBase"
           },
           {
-            "title": "Order Response",
+            "title": "Order Calculated",
             "type": "object",
             "additionalProperties": false,
             "description": "Order information.",
@@ -1285,10 +1285,10 @@
               "customer": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/CustomerResponse"
+                    "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
                   },
                   {
-                    "$ref": "#/components/schemas/CustomerIdResponse"
+                    "$ref": "#/components/schemas/CustomerId"
                   }
                 ]
               },
@@ -1310,7 +1310,7 @@
         "title": "Order Response No Customer Data",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderResponseBase"
+            "$ref": "#/components/schemas/OrderCalculatedBase"
           },
           {
             "title": "Order Customer And Referrer Ids Objects",
@@ -1322,7 +1322,7 @@
                 "description": "If only `customer_id` was provided, customer return data will be limited.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/CustomerIdResponse"
+                    "$ref": "#/components/schemas/CustomerId"
                   }
                 ]
               },
@@ -1407,7 +1407,7 @@
             "description": "Customer's information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -1415,7 +1415,7 @@
             "description": "Order information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderRequest"
+                "$ref": "#/components/schemas/Order"
               }
             ]
           },
@@ -1458,7 +1458,7 @@
             "description": "Customer's information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -1493,14 +1493,14 @@
                 "type": "array",
                 "description": "Array of items applied to the order.",
                 "items": {
-                  "$ref": "#/components/schemas/OrderItemRequest"
+                  "$ref": "#/components/schemas/OrderItem"
                 }
               },
               "customer": {
                 "description": "This is an object containing information about the customer.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/CustomerRequest"
+                    "$ref": "#/components/schemas/Customer"
                   }
                 ]
               },
@@ -1581,7 +1581,7 @@
             "description": "Customer's information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -1616,14 +1616,14 @@
                 "type": "array",
                 "description": "Array of items applied to the order.",
                 "items": {
-                  "$ref": "#/components/schemas/OrderItemRequest"
+                  "$ref": "#/components/schemas/OrderItem"
                 }
               },
               "customer": {
                 "description": "This is an object containing information about the customer.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/CustomerRequest"
+                    "$ref": "#/components/schemas/Customer"
                   }
                 ]
               },
@@ -1705,7 +1705,7 @@
         "title": "Referrer Request",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerRequest"
+            "$ref": "#/components/schemas/Customer"
           }
         ]
       },
@@ -1713,7 +1713,7 @@
         "title": "Referrer Response",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         ]
       },
@@ -1721,7 +1721,7 @@
         "title": "Referrer Id",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerIdResponse"
+            "$ref": "#/components/schemas/CustomerId"
           }
         ]
       },
@@ -1797,7 +1797,7 @@
         "description": "Request body schema for **POST** `/customers`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerRequest"
+            "$ref": "#/components/schemas/Customer"
           }
         ]
       },
@@ -1815,12 +1815,12 @@
         "description": "Response body schema for **PUT** `/customers/{customerId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         ]
       },
-      "CustomerRequest": {
-        "title": "Customer Request",
+      "Customer": {
+        "title": "Customer",
         "allOf": [
           {
             "type": "object",
@@ -1841,7 +1841,7 @@
           }
         ]
       },
-      "CustomerIdResponse": {
+      "CustomerId": {
         "title": "Customer Id",
         "type": "object",
         "properties": {
@@ -1868,12 +1868,12 @@
         "title": "Customers Create Response Body",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         ]
       },
-      "CustomerResponse": {
-        "title": "Customer Response",
+      "CustomerWithSummaryLoyaltyReferrals": {
+        "title": "Customer With Summary Loyalty Referrals",
         "allOf": [
           {
             "type": "object",
@@ -2219,9 +2219,9 @@
           }
         }
       },
-      "OrderItemRequest": {
+      "OrderItem": {
         "type": "object",
-        "title": "Order Item Request",
+        "title": "Order Item",
         "properties": {
           "sku_id": {
             "type": "string",
@@ -2392,9 +2392,9 @@
           }
         }
       },
-      "OrderItemResponse": {
+      "OrderItemCalculated": {
         "type": "object",
-        "title": "Order Item Response",
+        "title": "Order Item Calculated",
         "properties": {
           "sku_id": {
             "type": "string",
@@ -2655,7 +2655,7 @@
             ]
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "session": {
             "description": "Schema model for session lock object. The session object contains information about the session key that was used to establish a session between multiple parallel validation and redemption requests.\n\n\n",
@@ -6504,7 +6504,7 @@
             ]
           },
           "code_config": {
-            "$ref": "#/components/schemas/CodeConfigResponse"
+            "$ref": "#/components/schemas/CodeConfigRequiredLengthCharsetPattern"
           },
           "is_referral_code": {
             "type": "boolean",
@@ -6575,8 +6575,8 @@
           }
         }
       },
-      "CodeConfigResponse": {
-        "title": "Code Config Response",
+      "CodeConfigRequiredLengthCharsetPattern": {
+        "title": "Code Config Required Length Charset Pattern",
         "allOf": [
           {
             "$ref": "#/components/schemas/CodeConfig"
@@ -9892,7 +9892,7 @@
             "description": "Contains information about the customer to whom the publication was directed.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -10049,7 +10049,7 @@
             "description": "The merchant’s publication ID if it is different from the Voucherify publication ID. It's an optional tracking identifier of a publication. It is really useful in case of an integration between multiple systems. It can be a publication ID from a CRM system, database or 3rd-party service. "
           },
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           },
           "vouchers_id": {
             "type": "array",
@@ -10266,7 +10266,7 @@
             "description": "Status of the publication attempt."
           },
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           },
           "vouchers_id": {
             "type": "array",
@@ -13433,7 +13433,7 @@
             "description": "Order information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderRequest"
+                "$ref": "#/components/schemas/Order"
               }
             ]
           },
@@ -13441,7 +13441,7 @@
             "description": "Customer's information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -13569,7 +13569,7 @@
             ]
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "applicable_to": {
             "$ref": "#/components/schemas/ApplicableTo"
@@ -13699,7 +13699,7 @@
             }
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "tracking_id": {
             "type": "string",
@@ -13754,7 +13754,7 @@
             }
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "tracking_id": {
             "type": "string",
@@ -14473,7 +14473,7 @@
             "description": "Contains the order details associated with the redemption.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderResponse"
+                "$ref": "#/components/schemas/OrderCalculated"
               }
             ]
           },
@@ -16024,10 +16024,10 @@
             "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed."
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "previous_order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "reward": {
             "$ref": "#/components/schemas/RedemptionRewardResult"
@@ -19629,10 +19629,10 @@
             "description": "Customer's `source_id`."
           },
           "customer": {
-            "$ref": "#/components/schemas/CustomerRequest"
+            "$ref": "#/components/schemas/Customer"
           },
           "order": {
-            "$ref": "#/components/schemas/OrderRequest"
+            "$ref": "#/components/schemas/Order"
           },
           "metadata": {
             "type": "object",
@@ -22743,7 +22743,7 @@
             "description": "Order object that is **required** when redeeming a pay with points reward.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderRequest"
+                "$ref": "#/components/schemas/Order"
               }
             ]
           },
@@ -23474,7 +23474,7 @@
             "type": "array",
             "description": "Contains array of customer objects.",
             "items": {
-              "$ref": "#/components/schemas/CustomerResponse"
+              "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
             }
           },
           "total": {
@@ -23494,7 +23494,7 @@
         "description": "Response body schema for **GET** `/customers/{customerId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         ]
       },
@@ -24152,7 +24152,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           },
           "unconfirmed_customer": {
             "type": "object",
@@ -24171,7 +24171,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         }
       },
@@ -24181,7 +24181,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         }
       },
@@ -24191,7 +24191,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         }
       },
@@ -24232,7 +24232,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           }
         },
         "additionalProperties": true,
@@ -24246,7 +24246,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           },
           "segment": {
             "$ref": "#/components/schemas/SimpleSegment"
@@ -24263,7 +24263,7 @@
         "type": "object",
         "properties": {
           "customer": {
-            "$ref": "#/components/schemas/CustomerResponse"
+            "$ref": "#/components/schemas/CustomerWithSummaryLoyaltyReferrals"
           },
           "segment": {
             "$ref": "#/components/schemas/SimpleSegment"
@@ -24581,7 +24581,7 @@
             "type": "integer"
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "event": {
             "type": "object"
@@ -24885,7 +24885,7 @@
             "$ref": "#/components/schemas/SimpleCustomer"
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "redemption": {
             "$ref": "#/components/schemas/RedemptionInternal"
@@ -25385,7 +25385,7 @@
         "description": "Response body schema for **PUT** `/orders/{orderId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           }
         ]
       },
@@ -25395,7 +25395,7 @@
         "description": "Response body schema for **POST** `/orders`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           }
         ]
       },
@@ -25514,7 +25514,7 @@
         "description": "Request body schema for **POST** `/orders`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderRequest"
+            "$ref": "#/components/schemas/Order"
           }
         ]
       },
@@ -25524,7 +25524,7 @@
         "description": "Request body schema for **PUT** `/orders/{orderId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderRequestBase"
+            "$ref": "#/components/schemas/OrderBase"
           }
         ]
       },
@@ -25582,7 +25582,7 @@
               }
             },
             {
-              "$ref": "#/components/schemas/OrderRequestBase"
+              "$ref": "#/components/schemas/OrderBase"
             }
           ]
         }
@@ -27802,7 +27802,7 @@
             "description": "Customer's information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -30320,7 +30320,7 @@
             "description": "This identifier is generated during voucher qualification based on your internal id (e.g., email, database ID). This is a hashed customer source ID."
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "stacking_rules": {
             "$ref": "#/components/schemas/QualificationsStackingRules"
@@ -30387,7 +30387,7 @@
             "description": "Customer's information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CustomerRequest"
+                "$ref": "#/components/schemas/Customer"
               }
             ]
           },
@@ -30395,7 +30395,7 @@
             "description": "Order information.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderRequest"
+                "$ref": "#/components/schemas/Order"
               }
             ]
           },
@@ -30617,7 +30617,7 @@
             "$ref": "#/components/schemas/RedeemableResult"
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponse"
+            "$ref": "#/components/schemas/OrderCalculated"
           },
           "validation_rule_id": {
             "type": "string",
@@ -47168,7 +47168,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "$ref": "#/components/schemas/CustomerRequest"
+              "$ref": "#/components/schemas/Customer"
             }
           },
           {

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -1306,8 +1306,8 @@
           }
         ]
       },
-      "OrderResponseNoCustomerData": {
-        "title": "Order Response No Customer Data",
+      "OrderCalculatedNoCustomerData": {
+        "title": "Order Calculated No Customer Data",
         "allOf": [
           {
             "$ref": "#/components/schemas/OrderCalculatedBase"
@@ -1343,7 +1343,7 @@
         "description": "Response body schema for **GET** `/orders/{orderId}`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/OrderResponseNoCustomerData"
+            "$ref": "#/components/schemas/OrderCalculatedNoCustomerData"
           }
         ]
       },
@@ -13899,7 +13899,7 @@
             "$ref": "#/components/schemas/RedemptionRollback"
           },
           "order": {
-            "$ref": "#/components/schemas/OrderResponseNoCustomerData"
+            "$ref": "#/components/schemas/OrderCalculatedNoCustomerData"
           }
         }
       },
@@ -15648,7 +15648,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderResponseNoCustomerData"
+                "$ref": "#/components/schemas/OrderCalculatedNoCustomerData"
               }
             ]
           },
@@ -15871,7 +15871,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/OrderResponseNoCustomerData"
+                "$ref": "#/components/schemas/OrderCalculatedNoCustomerData"
               }
             ]
           },
@@ -25493,7 +25493,7 @@
             "type": "array",
             "description": "Contains array of order objects.",
             "items": {
-              "$ref": "#/components/schemas/OrderResponseNoCustomerData"
+              "$ref": "#/components/schemas/OrderCalculatedNoCustomerData"
             }
           },
           "total": {
@@ -27786,9 +27786,6 @@
         "title": "Orders Export Response Body",
         "description": "Response body schema for **POST** `/orders/export`.",
         "allOf": [
-          {
-            "$ref": "#/components/schemas/ExportResponseBase"
-          },
           {
             "$ref": "#/components/schemas/ExportOrder"
           }
@@ -33181,300 +33178,30 @@
           "NON_EXPIRING"
         ]
       },
-      "ExportVouchersRequest": {
-        "title": "Export Vouchers",
-        "type": "object",
-        "properties": {
-          "exported_object": {
-            "type": "string",
-            "enum": [
-              "voucher"
-            ],
-            "description": "The type of object to be exported."
-          },
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "order": {
-                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportVoucherOrder"
-                  }
-                ]
-              },
-              "fields": {
-                "type": "array",
-                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                "items": {
-                  "$ref": "#/components/schemas/ExportVoucherFields"
-                }
-              },
-              "filters": {
-                "description": "Filter conditions.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportVoucherFilters"
-                  }
-                ]
-              }
-            },
-            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-          }
-        },
-        "required": [
-          "exported_object"
-        ]
-      },
-      "ExportRedemptionsRequest": {
-        "title": "Export Redemptions",
-        "type": "object",
-        "properties": {
-          "exported_object": {
-            "type": "string",
-            "enum": [
-              "redemption"
-            ],
-            "description": "The type of object to be exported."
-          },
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "order": {
-                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportRedemptionOrder"
-                  }
-                ]
-              },
-              "fields": {
-                "type": "array",
-                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                "items": {
-                  "$ref": "#/components/schemas/ExportRedemptionFields"
-                }
-              },
-              "filters": {
-                "description": "Filter conditions.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportRedemptionFilters"
-                  }
-                ]
-              }
-            },
-            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-          }
-        },
-        "required": [
-          "exported_object"
-        ]
-      },
-      "ExportCustomersRequest": {
-        "title": "Export Customers Request",
-        "type": "object",
-        "properties": {
-          "exported_object": {
-            "type": "string",
-            "enum": [
-              "customer"
-            ],
-            "description": "The type of object to be exported."
-          },
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "order": {
-                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportCustomerOrder"
-                  }
-                ]
-              },
-              "fields": {
-                "type": "array",
-                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                "items": {
-                  "$ref": "#/components/schemas/ExportCustomerFields"
-                }
-              },
-              "filters": {
-                "description": "Filter conditions.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportCustomerFilters"
-                  }
-                ]
-              }
-            },
-            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-          }
-        },
-        "required": [
-          "exported_object"
-        ]
-      },
-      "ExportPublicationsRequest": {
-        "title": "Export Publications Request",
-        "type": "object",
-        "properties": {
-          "exported_object": {
-            "type": "string",
-            "enum": [
-              "publication"
-            ],
-            "description": "The type of object to be exported."
-          },
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "order": {
-                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportPublicationOrder"
-                  }
-                ]
-              },
-              "fields": {
-                "type": "array",
-                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                "items": {
-                  "$ref": "#/components/schemas/ExportPublicationFields"
-                }
-              },
-              "filters": {
-                "description": "Filter conditions.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportPublicationFilters"
-                  }
-                ]
-              }
-            },
-            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-          }
-        },
-        "required": [
-          "exported_object"
-        ]
-      },
-      "ExportPointsExpirationsRequest": {
-        "title": "Export Points Expirations Request",
-        "type": "object",
-        "properties": {
-          "exported_object": {
-            "type": "string",
-            "enum": [
-              "points_expiration"
-            ],
-            "description": "The type of object to be exported."
-          },
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "order": {
-                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportPointsExpirationOrder"
-                  }
-                ]
-              },
-              "fields": {
-                "type": "array",
-                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                "items": {
-                  "$ref": "#/components/schemas/ExportPointsExpirationFields"
-                }
-              },
-              "filters": {
-                "description": "Filter conditions.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportPointsExpirationFilters"
-                  }
-                ]
-              }
-            },
-            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-          }
-        },
-        "required": [
-          "exported_object"
-        ]
-      },
-      "ExportVouchersTransactionsExpirationRequest": {
-        "title": "ExportVouchersTransactionsExpirationRequest",
-        "type": "object",
-        "properties": {
-          "exported_object": {
-            "type": "string",
-            "enum": [
-              "voucher_transactions"
-            ],
-            "description": "The type of object to be exported."
-          },
-          "parameters": {
-            "type": "object",
-            "properties": {
-              "order": {
-                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportVoucherTransactionsOrder"
-                  }
-                ]
-              },
-              "fields": {
-                "type": "array",
-                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                "items": {
-                  "$ref": "#/components/schemas/ExportVoucherTransactionsFields"
-                }
-              },
-              "filters": {
-                "description": "Filter conditions.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExportVoucherTransactionsFilters"
-                  }
-                ]
-              }
-            },
-            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-          }
-        },
-        "required": [
-          "exported_object"
-        ]
-      },
       "ExportsCreateRequestBody": {
         "description": "Request body schema for **POST** `/exports`.",
         "title": "Exports Create Request Body",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ExportVouchersRequest"
+            "$ref": "#/components/schemas/ExportVoucherBase"
           },
           {
-            "$ref": "#/components/schemas/ExportRedemptionsRequest"
+            "$ref": "#/components/schemas/ExportRedemptionBase"
           },
           {
-            "$ref": "#/components/schemas/ExportCustomersRequest"
+            "$ref": "#/components/schemas/ExportCustomerBase"
           },
           {
-            "$ref": "#/components/schemas/ExportPublicationsRequest"
+            "$ref": "#/components/schemas/ExportPublicationBase"
           },
           {
-            "$ref": "#/components/schemas/ExportOrderRequest"
+            "$ref": "#/components/schemas/ExportOrderBase"
           },
           {
-            "$ref": "#/components/schemas/ExportPointsExpirationsRequest"
+            "$ref": "#/components/schemas/ExportPointsExpirationBase"
           },
           {
-            "$ref": "#/components/schemas/ExportVouchersTransactionsExpirationRequest"
+            "$ref": "#/components/schemas/ExportVoucherTransactionsExpirationBase"
           }
         ],
         "type": "object"
@@ -33547,30 +33274,30 @@
         "title": "Export",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ExportVoucherRequest"
+            "$ref": "#/components/schemas/ExportVoucher"
           },
           {
-            "$ref": "#/components/schemas/ExportRedemptionRequest"
+            "$ref": "#/components/schemas/ExportRedemption"
           },
           {
-            "$ref": "#/components/schemas/ExportCustomerRequest"
+            "$ref": "#/components/schemas/ExportCustomer"
           },
           {
-            "$ref": "#/components/schemas/ExportPublicationRequest"
+            "$ref": "#/components/schemas/ExportPublication"
           },
           {
-            "$ref": "#/components/schemas/ExportOrderRequest"
+            "$ref": "#/components/schemas/ExportOrder"
           },
           {
-            "$ref": "#/components/schemas/ExportPointsExpirationRequest"
+            "$ref": "#/components/schemas/ExportPointsExpiration"
           },
           {
-            "$ref": "#/components/schemas/ExportVoucherTransactionsExpirationRequest"
+            "$ref": "#/components/schemas/ExportVoucherTransactionsExpiration"
           }
         ]
       },
-      "ExportResponseBase": {
-        "title": "Export Response Base",
+      "ExportScheduledBase": {
+        "title": "Export Scheduled Base",
         "type": "object",
         "properties": {
           "id": {
@@ -33623,79 +33350,81 @@
         "description": "Response body schema for **POST** `/exports`.",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/ExportVoucher"
+            "$ref": "#/components/schemas/ExportVoucherScheduled"
           },
           {
-            "$ref": "#/components/schemas/ExportRedemption"
+            "$ref": "#/components/schemas/ExportRedemptionScheduled"
           },
           {
-            "$ref": "#/components/schemas/ExportCustomer"
+            "$ref": "#/components/schemas/ExportCustomerScheduled"
           },
           {
-            "$ref": "#/components/schemas/ExportPublication"
+            "$ref": "#/components/schemas/ExportPublicationScheduled"
           },
           {
-            "$ref": "#/components/schemas/ExportOrder"
+            "$ref": "#/components/schemas/ExportOrderScheduled"
           },
           {
-            "$ref": "#/components/schemas/ExportPointsExpiration"
+            "$ref": "#/components/schemas/ExportPointsExpirationScheduled"
           },
           {
-            "$ref": "#/components/schemas/ExportVoucherTransactionsExpiration"
+            "$ref": "#/components/schemas/ExportVoucherTransactionsExpirationScheduled"
           }
         ]
       },
-      "ExportVoucherRequest": {
-        "title": "Export Voucher Request",
+      "ExportVoucherBase": {
+        "title": "Export Voucher Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "voucher"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportVoucherOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportVoucherFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportVoucherFilters"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportVoucherScheduled": {
+        "title": "Export Voucher Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "title": "Export Vouchers Request",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "voucher"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportVoucherFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherFilters"
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportVoucherBase"
           }
         ]
       },
@@ -33704,52 +33433,10 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "title": "Export Vouchers",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "voucher"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportVoucherFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherFilters"
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportVoucherBase"
           }
         ]
       },
@@ -33961,58 +33648,60 @@
         ],
         "type": "string"
       },
-      "ExportRedemptionRequest": {
-        "title": "Export Redemption Request",
+      "ExportRedemptionBase": {
+        "title": "Export Redemption Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "redemption"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportRedemptionOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportRedemptionFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportRedemptionFilters"
+                  }
+                ]
+              }
+            },
+            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportRedemptionScheduled": {
+        "title": "Export Redemption Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "title": "Export Redemptions Request",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "redemption"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportRedemptionOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportRedemptionFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportRedemptionFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportRedemptionBase"
           }
         ]
       },
@@ -34021,53 +33710,10 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "title": "Export Redemptions",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "redemption"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportRedemptionOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportRedemptionFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportRedemptionFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportRedemptionBase"
           }
         ]
       },
@@ -34132,58 +33778,60 @@
           }
         }
       },
-      "ExportCustomerRequest": {
-        "title": "Export Customer Request",
+      "ExportCustomerBase": {
+        "title": "Export Customer Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "customer"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportCustomerOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportCustomerFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportCustomerFilters"
+                  }
+                ]
+              }
+            },
+            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportCustomerScheduled": {
+        "title": "Export Customer Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "title": "Export Customer Request",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "customer"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportCustomerOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportCustomerFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportCustomerFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportCustomerBase"
           }
         ]
       },
@@ -34192,52 +33840,10 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "customer"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportCustomerOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportCustomerFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportCustomerFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportCustomerBase"
           }
         ]
       },
@@ -34340,57 +33946,60 @@
           }
         }
       },
-      "ExportPublicationRequest": {
-        "title": "Export Publication Request",
+      "ExportPublicationBase": {
+        "title": "Export Publication Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "publication"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportPublicationOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportPublicationFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportPublicationFilters"
+                  }
+                ]
+              }
+            },
+            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportPublicationScheduled": {
+        "title": "Export Publication Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "publication"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPublicationOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportPublicationFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPublicationFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportPublicationBase"
           }
         ]
       },
@@ -34399,52 +34008,10 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "publication"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPublicationOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportPublicationFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPublicationFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportPublicationBase"
           }
         ]
       },
@@ -34481,58 +34048,60 @@
           }
         }
       },
-      "ExportOrderRequest": {
-        "title": "Export Orders Request",
+      "ExportOrderBase": {
+        "title": "Export Order Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "order"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportOrderOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportOrderFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportOrderFilters"
+                  }
+                ]
+              }
+            },
+            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportOrderScheduled": {
+        "title": "Export Orders Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "title": "Export Orders Request",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "order"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportOrderOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportOrderFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportOrderFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportOrderBase"
           }
         ]
       },
@@ -34541,53 +34110,10 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "title": "Export Orders",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "order"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportOrderOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportOrderFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportOrderFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportOrderBase"
           }
         ]
       },
@@ -34640,111 +34166,73 @@
           }
         }
       },
-      "ExportPointsExpirationRequest": {
-        "title": "Export Points Expiration Request",
+      "ExportPointsExpirationBase": {
+        "title": "Export Points Expiration Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "points_expiration"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportPointsExpirationOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportPointsExpirationFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportPointsExpirationFilters"
+                  }
+                ]
+              }
+            },
+            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportPointsExpirationScheduled": {
+        "title": "Export Points Expiration Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "points_expiration"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPointsExpirationOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportPointsExpirationFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPointsExpirationFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportPointsExpirationBase"
           }
         ]
       },
       "ExportPointsExpiration": {
         "title": "Export Points Expiration",
         "type": "object",
+        "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "points_expiration"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPointsExpirationOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportPointsExpirationFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportPointsExpirationFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportPointsExpirationBase"
           }
         ]
       },
@@ -34775,57 +34263,60 @@
           }
         }
       },
-      "ExportVoucherTransactionsExpirationRequest": {
-        "title": "Export Vouchers Transactions Expiration Request",
+      "ExportVoucherTransactionsExpirationBase": {
+        "title": "Export Voucher Transactions Expiration Base",
+        "type": "object",
+        "properties": {
+          "exported_object": {
+            "type": "string",
+            "enum": [
+              "voucher_transactions"
+            ],
+            "description": "The type of object to be exported."
+          },
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportVoucherTransactionsOrder"
+                  }
+                ]
+              },
+              "fields": {
+                "type": "array",
+                "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
+                "items": {
+                  "$ref": "#/components/schemas/ExportVoucherTransactionsFields"
+                }
+              },
+              "filters": {
+                "description": "Filter conditions.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExportVoucherTransactionsFilters"
+                  }
+                ]
+              }
+            },
+            "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
+          }
+        },
+        "required": [
+          "exported_object"
+        ]
+      },
+      "ExportVoucherTransactionsExpirationScheduled": {
+        "title": "Export Vouchers Transactions Expiration Scheduled",
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportBase"
+            "$ref": "#/components/schemas/ExportScheduledBase"
           },
           {
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "voucher_transactions"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherTransactionsOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportVoucherTransactionsFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherTransactionsFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportVoucherTransactionsExpirationBase"
           }
         ]
       },
@@ -34834,53 +34325,10 @@
         "type": "object",
         "allOf": [
           {
-            "$ref": "#/components/schemas/ExportResponseBase"
+            "$ref": "#/components/schemas/ExportBase"
           },
           {
-            "title": "Export Vouchers Transactions Expiration",
-            "type": "object",
-            "properties": {
-              "exported_object": {
-                "type": "string",
-                "enum": [
-                  "voucher_transactions"
-                ],
-                "description": "The type of object to be exported."
-              },
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "order": {
-                    "description": "How the export is filtered, where the dash - preceding a sorting option means sorting in a descending order.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherTransactionsOrder"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Array of strings containing the data in the export. These fields define the headers in the CSV file.",
-                    "items": {
-                      "$ref": "#/components/schemas/ExportVoucherTransactionsFields"
-                    }
-                  },
-                  "filters": {
-                    "description": "Filter conditions.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/ExportVoucherTransactionsFilters"
-                      }
-                    ]
-                  }
-                },
-                "description": "List of available fields and filters that can be exported with an order along with the sorting order of the returned data."
-              }
-            },
-            "required": [
-              "exported_object",
-              "parameters"
-            ]
+            "$ref": "#/components/schemas/ExportVoucherTransactionsExpirationBase"
           }
         ]
       },

--- a/scripts/md-tables.ts
+++ b/scripts/md-tables.ts
@@ -19,9 +19,9 @@ export const mdTables: [string, string?][] = [
   ],
   ["EarningRule", "LOYALTIES-API-Earning-Rule-Object.md"],
   ["LoyaltyTier", "LOYALTIES-API-Loyalty-Tier-Object.md"],
-  ["CustomerResponse", "CUSTOMERS-API-Customer-Object.md"],
+  ["CustomerWithSummaryLoyaltyReferrals", "CUSTOMERS-API-Customer-Object.md"],
   ["CustomerActivity", "CUSTOMERS-API-Customer-Activity-Object.md"],
-  ["OrderResponse", "ORDERS-API-Order-Object.md"],
+  ["OrderCalculated", "ORDERS-API-Order-Object.md"],
   ["Product", "PRODUCTS-API-Product-Object.md"],
   ["Sku", "PRODUCTS-API-SKU-Object.md"],
   [

--- a/scripts/md-tables.ts
+++ b/scripts/md-tables.ts
@@ -28,7 +28,7 @@ export const mdTables: [string, string?][] = [
     "ProductCollectionsItem",
     "PRODUCT-COLLECTIONS-API-Product-Collection-Object.md",
   ],
-  ["ValidationRuleResponse", "VALIDATION-RULES-API-Validation-Rule-Object.md"],
+  ["ValidationRule", "VALIDATION-RULES-API-Validation-Rule-Object.md"],
   [
     "ValidationRuleAssignment",
     "VALIDATION-RULES-API-Validation-Rule-Assignment-Object.md",


### PR DESCRIPTION
Fixed naming of following schemas:
```
[
  'CustomerRequest',
  'CustomerResponse',
  'ExportCustomersRequest',
  'ExportOrderRequest',
  'ExportPointsExpirationsRequest',
  'ExportPublicationsRequest',
  'ExportRedemptionsRequest',
  'ExportResponseBase',
  'ExportVouchersRequest',
  'ExportVouchersTransactionsExpirationRequest',
  'OrderRequest',
  'OrderRequestBase',
  'OrderResponse',
  'OrderResponseNoCustomerData',
  'SimpleCustomerResponse',
  'ValidationRuleRequest',
  'ValidationRuleResponse',
  'CustomerIdResponse',
  'ExportCustomerRequest',
  'ExportPointsExpirationRequest',
  'ExportPublicationRequest',
  'ExportRedemptionRequest',
  'ExportVoucherRequest',
  'ExportVoucherTransactionsExpirationRequest',
  'OrderItemRequest',
  'OrderResponseBase',
  'ReferrerRequest',
  'ReferrerResponse',
  'CodeConfigResponse',
  'OrderItemResponse'
]
```