### PR TITLE
Referrals tag order

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,10 @@
 
 Older changes in [DEPRECATED.md](DEPRECATED.md)
 
+## 2024-06-25
+
+- Changed the order of tags – `Referrals` is now under `Loyalties`
+
 ## 2024-06-24
 
 `OpenAPI.json`:

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -83,6 +83,10 @@
       "description": "Manage loyalty campaigns."
     },
     {
+      "name": "Referrals",
+      "description": "List referrals."
+    },
+    {
       "name": "Customers",
       "description": "Manage customers."
     },
@@ -133,10 +137,6 @@
     {
       "name": "Locations",
       "description": "List locations."
-    },
-    {
-      "name": "Referrals",
-      "description": "List referrals."
     },
     {
       "name": "Bin",


### PR DESCRIPTION
Changed order of the Referrals tag/section to be under Loyalties as per @wpr0k0p request