### PR TITLE
PW – `access_settings_assignments` for Areas and Stores

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -7,7 +7,7 @@ Older changes in [DEPRECATED.md](DEPRECATED.md)
 ## 2024-07-10
 
 `OpenAPI.json` and `OpenAPIWebhooks.json`:
-- Added `AccessSettingsAssignmentsList` and `AreaStoreCampaignAssignment` schemas for the Areas and Stores feature
+- Added `AccessSettingsCampaignAssignmentsList` and `AreaStoreCampaignAssignment` schemas for the Areas and Stores feature
 - Added `access_settings_assignments` field to the `Campaign` schema
 
 ## 2024-06-25

--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,12 @@
 
 Older changes in [DEPRECATED.md](DEPRECATED.md)
 
+## 2024-07-10
+
+`OpenAPI.json` and `OpenAPIWebhooks.json`:
+- Added `AccessSettingsAssignmentsList` and `AreaStoreCampaignAssignment` schemas for the Areas and Stores feature
+- Added `access_settings_assignments` field to the `Campaign` schema
+
 ## 2024-06-25
 
 - Changed the order of tags – `Referrals` is now under `Loyalties`

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -8443,7 +8443,7 @@
           "total": {
             "type": "integer",
             "description": "Total number of areas and stores to which the campaign is assigned.",
-            "min": 0
+            "minimum": 0
           }
         },
         "required": [

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -7234,55 +7234,6 @@
             "type": "boolean",
             "description": "Indicates whether the resource can be deleted."
           },
-          "access_settings_assignments": {
-            "type": "object",
-            "description": "",
-            "readOnly": true,
-            "properties": {
-              "object": {
-                "type": "object",
-                "description": ""
-              },
-              "data_ref": {
-                "type": "object",
-                "description": ""
-              },
-              "data": {
-                "type": "array",
-                "description": "",
-                "items": {
-                  "type": "object",
-                  "description": {},
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "",
-                      "example": "arsca_0ef5ee192117ae2416"
-                    },
-                    "area_id": {
-                      "type": "string",
-                      "description": "",
-                      "example": "ar_0ea6cd7b781b8f857f"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "description": "",
-                      "example": "2024-06-25T19:04:16.260Z"
-                    },
-                    "object": {
-                      "type": "string",
-                      "description": "",
-                      "example": "area_store_campaign_assignment"
-                    }
-                  }
-                }
-              },
-              "total": {
-                "type": "integer",
-                "description": ""
-              }
-            }
-          },
           "category_id": {
             "type": "string",
             "nullable": true,
@@ -7340,6 +7291,9 @@
               },
               "validation_rules_assignments": {
                 "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              },
+              "access_settings_assignments": {
+                "$ref": "#/components/schemas/AccessSettingsAssignmentsList"
               }
             }
           }
@@ -8456,6 +8410,81 @@
         },
         "required": [
           "code"
+        ]
+      },
+      "AccessSettingsAssignmentsList": {
+        "title": "Access Settings Assignments List",
+        "type": "object",
+        "description": "Lists all assignments of the campaign to areas and stores if the Areas and Stores feature is enabled (Enterprise feature).",
+        "properties": {
+          "object": {
+            "type": "string",
+            "default": "list",
+            "description": "The type of the object represented by JSON. Default is `list`. This object stores information about campaign assignments to areas and stores",
+            "enum": [
+              "list"
+            ]
+          },
+          "data_ref": {
+            "type": "string",
+            "default": "data",
+            "description": "Identifies the name of the attribute that contains the array of campaign assignments.",
+            "enum": [
+              "data"
+            ]
+          },
+          "data": {
+            "type": "array",
+            "description": "Contains an array of campaign assignments.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the campaign assignment.",
+                  "example": "arsca_0ef5ee192117ae2416"
+                },
+                "area_id": {
+                  "type": "string",
+                  "description": "Unique identifier of the area to which the campaign is assigned.",
+                  "example": "ar_0ea6cd7b781b8f857f"
+                },
+                "area_store_id": {
+                  "type": "string",
+                  "description": "Unique identifier of the store to which the campaign is assigned.",
+                  "example": "ars_0ec347e2016bed85f4"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Date and time when the assignment was made. The value is shown in the ISO 8601 format.",
+                  "format": "date-time",
+                  "example": "2024-06-25T19:04:16.260Z"
+                },
+                "object": {
+                  "type": "string",
+                  "description": "The type of the object represented by JSON. This object stores information about the campaign assignment to areas or stores.",
+                  "example": "area_store_campaign_assignment"
+                }
+              },
+              "required": [
+                "id",
+                "area_id",
+                "created_at",
+                "object"
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of areas and stores to which the campaign is assigned.",
+            "min": 0
+          }
+        },
+        "required": [
+          "object",
+          "data_ref",
+          "data",
+          "total"
         ]
       },
       "2_req_examine_qualification": {
@@ -20537,7 +20566,7 @@
       },
       "8_obj_loyalty_campaign_object": {
         "title": "Loyalty Campaign Object",
-        "description": "This is an object representing a loyalty campaign.  \n\nThe loyalty campaign object contains details about the loyalty campaign. You can use dedicated endpoints to list loyalty campaigns, list loyalty card holders, member activities, active rewards, earning rules, loyalty tiers for given loyalty campaign.",
+        "description": "This is an object representing a loyalty campaign.\n\nThe loyalty campaign object contains details about the loyalty campaign. You can use dedicated endpoints to list loyalty campaigns, list loyalty card holders, member activities, active rewards, earning rules, loyalty tiers for given loyalty campaign.",
         "type": "object",
         "properties": {
           "id": {
@@ -20681,6 +20710,9 @@
           "protected": {
             "type": "boolean",
             "description": "Indicates whether the resource can be deleted."
+          },
+          "access_settings_assignments": {
+            "$ref": "#/components/schemas/AccessSettingsAssignmentsList"
           },
           "category_id": {
             "type": "string",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -8437,41 +8437,7 @@
             "type": "array",
             "description": "Contains an array of campaign assignments.",
             "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Unique identifier of the campaign assignment.",
-                  "example": "arsca_0ef5ee192117ae2416"
-                },
-                "area_id": {
-                  "type": "string",
-                  "description": "Unique identifier of the area to which the campaign is assigned.",
-                  "example": "ar_0ea6cd7b781b8f857f"
-                },
-                "area_store_id": {
-                  "type": "string",
-                  "description": "Unique identifier of the store to which the campaign is assigned.",
-                  "example": "ars_0ec347e2016bed85f4"
-                },
-                "created_at": {
-                  "type": "string",
-                  "description": "Date and time when the assignment was made. The value is shown in the ISO 8601 format.",
-                  "format": "date-time",
-                  "example": "2024-06-25T19:04:16.260Z"
-                },
-                "object": {
-                  "type": "string",
-                  "description": "The type of the object represented by JSON. This object stores information about the campaign assignment to areas or stores.",
-                  "example": "area_store_campaign_assignment"
-                }
-              },
-              "required": [
-                "id",
-                "area_id",
-                "created_at",
-                "object"
-              ]
+              "$ref": "#/components/schemas/AreaStoreCampaignAssignment"
             }
           },
           "total": {
@@ -8485,6 +8451,45 @@
           "data_ref",
           "data",
           "total"
+        ]
+      },
+      "AreaStoreCampaignAssignment": {
+        "title": "Areas and Stores Campain Assignment",
+        "type": "object",
+        "description": "An object representing an assignment of a campaign to an area or store.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the campaign assignment.",
+            "example": "arsca_0ef5ee192117ae2416"
+          },
+          "area_id": {
+            "type": "string",
+            "description": "Unique identifier of the area to which the campaign is assigned.",
+            "example": "ar_0ea6cd7b781b8f857f"
+          },
+          "area_store_id": {
+            "type": "string",
+            "description": "Unique identifier of the store to which the campaign is assigned.",
+            "example": "ars_0ec347e2016bed85f4"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Date and time when the assignment was made. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "example": "2024-06-25T19:04:16.260Z"
+          },
+          "object": {
+            "type": "string",
+            "description": "The type of the object represented by JSON. This object stores information about the campaign assignment to areas or stores.",
+            "example": "area_store_campaign_assignment"
+          }
+        },
+        "required": [
+          "id",
+          "area_id",
+          "created_at",
+          "object"
         ]
       },
       "2_req_examine_qualification": {

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -48935,6 +48935,29 @@
               }
             }
           },
+          "403": {
+            "description": "Returns an error if the user is missing the access to an area or a store to which the campaign with this ID has been assigned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "code": 403,
+                      "key": "forbidden",
+                      "message": "Forbidden",
+                      "details": "Resource campaign with id camp_7u3ZPLSByANMXjBkAs4kT2nS is not accessible in given context",
+                      "request_id": "v-0f005192bfce923bb7",
+                      "resource_id": "camp_7u3ZPLSByANMXjBkAs4kT2nS",
+                      "resource_type": "campaign"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Returns an error when requesting the campaign that has been deleted or cannot be found.",
             "content": {
@@ -49081,6 +49104,29 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Returns an error if the user is missing the access to an area or a store to which the campaign with this ID has been assigned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "code": 403,
+                      "key": "forbidden",
+                      "message": "Forbidden",
+                      "details": "Resource campaign with id camp_7u3ZPLSByANMXjBkAs4kT2nS is not accessible in given context",
+                      "request_id": "v-0f005192bfce923bb7",
+                      "resource_id": "camp_7u3ZPLSByANMXjBkAs4kT2nS",
+                      "resource_type": "campaign"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -49114,6 +49160,29 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CampaignsDeleteResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Returns an error if the user is missing the access to an area or a store to which the campaign with this ID has been assigned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "code": 403,
+                      "key": "forbidden",
+                      "message": "Forbidden",
+                      "details": "Resource campaign with id camp_7u3ZPLSByANMXjBkAs4kT2nS is not accessible in given context",
+                      "request_id": "v-0f005192bfce923bb7",
+                      "resource_id": "camp_7u3ZPLSByANMXjBkAs4kT2nS",
+                      "resource_type": "campaign"
+                    }
+                  }
                 }
               }
             }

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -7293,7 +7293,7 @@
                 "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
               },
               "access_settings_assignments": {
-                "$ref": "#/components/schemas/AccessSettingsAssignmentsList"
+                "$ref": "#/components/schemas/AccessSettingsCampaignAssignmentsList"
               }
             }
           }
@@ -8412,8 +8412,8 @@
           "code"
         ]
       },
-      "AccessSettingsAssignmentsList": {
-        "title": "Access Settings Assignments List",
+      "AccessSettingsCampaignAssignmentsList": {
+        "title": "Access Settings Campaign Assignments List",
         "type": "object",
         "description": "Lists all assignments of the campaign to areas and stores if the Areas and Stores feature is enabled (Enterprise feature).",
         "properties": {
@@ -8482,7 +8482,8 @@
           "object": {
             "type": "string",
             "description": "The type of the object represented by JSON. This object stores information about the campaign assignment to areas or stores.",
-            "example": "area_store_campaign_assignment"
+            "default": "area_store_campaign_assignment",
+            "enum": ["area_store_campaign_assignment"]
           }
         },
         "required": [
@@ -20717,7 +20718,7 @@
             "description": "Indicates whether the resource can be deleted."
           },
           "access_settings_assignments": {
-            "$ref": "#/components/schemas/AccessSettingsAssignmentsList"
+            "$ref": "#/components/schemas/AccessSettingsCampaignAssignmentsList"
           },
           "category_id": {
             "type": "string",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -7234,6 +7234,55 @@
             "type": "boolean",
             "description": "Indicates whether the resource can be deleted."
           },
+          "access_settings_assignments": {
+            "type": "object",
+            "description": "",
+            "readOnly": true,
+            "properties": {
+              "object": {
+                "type": "object",
+                "description": ""
+              },
+              "data_ref": {
+                "type": "object",
+                "description": ""
+              },
+              "data": {
+                "type": "array",
+                "description": "",
+                "items": {
+                  "type": "object",
+                  "description": {},
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "",
+                      "example": "arsca_0ef5ee192117ae2416"
+                    },
+                    "area_id": {
+                      "type": "string",
+                      "description": "",
+                      "example": "ar_0ea6cd7b781b8f857f"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "",
+                      "example": "2024-06-25T19:04:16.260Z"
+                    },
+                    "object": {
+                      "type": "string",
+                      "description": "",
+                      "example": "area_store_campaign_assignment"
+                    }
+                  }
+                }
+              },
+              "total": {
+                "type": "integer",
+                "description": ""
+              }
+            }
+          },
           "category_id": {
             "type": "string",
             "nullable": true,

--- a/reference/OpenAPIWebhooks.json
+++ b/reference/OpenAPIWebhooks.json
@@ -6822,6 +6822,81 @@
           }
         }
       },
+      "AccessSettingsAssignmentsList": {
+        "title": "Access Settings Assignments List",
+        "type": "object",
+        "description": "Lists all assignments of the campaign to areas and stores if the Areas and Stores feature is enabled (Enterprise feature).",
+        "properties": {
+          "object": {
+            "type": "string",
+            "default": "list",
+            "description": "The type of the object represented by JSON. Default is `list`. This object stores information about campaign assignments to areas and stores",
+            "enum": [
+              "list"
+            ]
+          },
+          "data_ref": {
+            "type": "string",
+            "default": "data",
+            "description": "Identifies the name of the attribute that contains the array of campaign assignments.",
+            "enum": [
+              "data"
+            ]
+          },
+          "data": {
+            "type": "array",
+            "description": "Contains an array of campaign assignments.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the campaign assignment.",
+                  "example": "arsca_0ef5ee192117ae2416"
+                },
+                "area_id": {
+                  "type": "string",
+                  "description": "Unique identifier of the area to which the campaign is assigned.",
+                  "example": "ar_0ea6cd7b781b8f857f"
+                },
+                "area_store_id": {
+                  "type": "string",
+                  "description": "Unique identifier of the store to which the campaign is assigned.",
+                  "example": "ars_0ec347e2016bed85f4"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Date and time when the assignment was made. The value is shown in the ISO 8601 format.",
+                  "format": "date-time",
+                  "example": "2024-06-25T19:04:16.260Z"
+                },
+                "object": {
+                  "type": "string",
+                  "description": "The type of the object represented by JSON. This object stores information about the campaign assignment to areas or stores.",
+                  "example": "area_store_campaign_assignment"
+                }
+              },
+              "required": [
+                "id",
+                "area_id",
+                "created_at",
+                "object"
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of areas and stores to which the campaign is assigned.",
+            "min": 0
+          }
+        },
+        "required": [
+          "object",
+          "data_ref",
+          "data",
+          "total"
+        ]
+      },
       "Any": {
         "oneOf": [
           {
@@ -7045,6 +7120,9 @@
               },
               "validation_rules_assignments": {
                 "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              },
+              "access_settings_assignments": {
+                "$ref": "#/components/schemas/AccessSettingsAssignmentsList"
               }
             }
           }


### PR DESCRIPTION
Add the `access_settings_assignments` field to various Campaign schemas throughout the API documentation.