### PR TITLE
ValidationsRedeemables schemas – changes

### DIFF
--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -14612,12 +14612,24 @@
           },
           "result": {
             "type": "object",
+            "description": "Includes the error object with details about the reason why the redeemable is inapplicable",
             "properties": {
               "error": {
                 "$ref": "#/components/schemas/Error"
               },
               "details": {
-                "type": "object"
+                "type": "object",
+                "description": "Provides details about the reason why the redeemable is inapplicable.",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Generic message from the `message` string shown in the `error` object or the message configured in a validation rule."
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Generic message from the `key` string shown in the `error` object."
+                  }
+                }
               }
             }
           },
@@ -14664,26 +14676,32 @@
             ]
           },
           "result": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultLimitExceeded"
-              },
-              {
-                "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultCategoryLimitExceeded"
-              },
-              {
-                "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultRedeemablesLimitExceeded"
-              },
-              {
-                "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultRedeemablesCategoryLimitExceeded"
-              },
-              {
-                "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultExclusionRulesNotMet"
-              },
-              {
-                "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultPrecedingValidationFailed"
+            "type": "object",
+            "description": "Provides details about the reason why the redeemable is skipped.",
+            "properties": {
+              "details": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultLimitExceeded"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultCategoryLimitExceeded"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultRedeemablesLimitExceeded"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultRedeemablesCategoryLimitExceeded"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultExclusionRulesNotMet"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ValidationsRedeemableSkippedResultPrecedingValidationFailed"
+                  }
+                ]
               }
-            ]
+            }
           },
           "metadata": {
             "type": "object",
@@ -14706,7 +14724,7 @@
       "ValidationsRedeemableSkippedResultLimitExceeded": {
         "title": "Validations Redeemable Skipped Result Limit Exceeded",
         "type": "object",
-        "description": "When applicable_redeemables_limit from stacking_rules is exceeded",
+        "description": "Displayed when the `applicable_redeemables_limit` defined in the stacking rules is exceeded.",
         "properties": {
           "key": {
             "type": "string",
@@ -14725,7 +14743,7 @@
       "ValidationsRedeemableSkippedResultCategoryLimitExceeded": {
         "title": "Validations Redeemable Skipped Result Category Limit Exceeded",
         "type": "object",
-        "description": "When applicable_redeemables_per_category_limit from stacking_rules is exceeded",
+        "description": "Displayed when `applicable_redeemables_per_category_limit` defined in the stacking rules is exceeded",
         "properties": {
           "key": {
             "type": "string",
@@ -14744,7 +14762,7 @@
       "ValidationsRedeemableSkippedResultRedeemablesLimitExceeded": {
         "title": "Validations Redeemable Skipped Result Redeemables Limit Exceeded",
         "type": "object",
-        "description": "When applicable_exclusive_redeemables_limit from stacking_rules is exceeded",
+        "description": "Displayed when `applicable_exclusive_redeemables_limit` defined in the  stacking rules is exceeded.",
         "properties": {
           "key": {
             "type": "string",
@@ -14763,7 +14781,7 @@
       "ValidationsRedeemableSkippedResultRedeemablesCategoryLimitExceeded": {
         "title": "Validations Redeemable Skipped Result Redeemables Category Limit Exceeded",
         "type": "object",
-        "description": "When applicable_exclusive_redeemables_per_category_limit from stacking_rules is exceeded",
+        "description": "Displayed when `applicable_exclusive_redeemables_per_category_limit` defined in the stacking rules is exceeded.",
         "properties": {
           "key": {
             "type": "string",
@@ -14782,7 +14800,7 @@
       "ValidationsRedeemableSkippedResultExclusionRulesNotMet": {
         "title": "Validations Redeemable Skipped Result Exclusion Rules Not Met",
         "type": "object",
-        "description": "When regular is skipped due to non-fulfilled exclusion rules",
+        "description": "Displayed when the redeemable cannot be applied because the exclusion rules are not fulfilled.",
         "properties": {
           "key": {
             "type": "string",
@@ -14801,7 +14819,7 @@
       "ValidationsRedeemableSkippedResultPrecedingValidationFailed": {
         "title": "Validations Redeemable Skipped Result Preceding Validation Failed",
         "type": "object",
-        "description": "For ALL mode when one of the preceding redeeambles is INAPPLICABLE so the rest is SKIPPED",
+        "description": "Displayed in the ALL application rule when one of the preceding redeeambles is `INAPPLICABLE`, so the rest becomes `SKIPPED`",
         "properties": {
           "key": {
             "type": "string",


### PR DESCRIPTION
Changes to a series of `ValidationsRedeemables` schemas:
- reworded and formatted some descriptions
- added descriptions where necessary
- added the `details` object to the `result` object in the `ValidationsRedeemableSkipped` schema