### PR TITLE
PW – Management API – POST Invite User, Return Keys

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,14 @@
 
 Older changes in [DEPRECATED.md](deprecated/DEPRECATED.md)
 
+## 2024-07-15
+
+`OpenAPI.json`:
+- Added a new endpoint, Invite a New User (**POST** `/management/v1/projects/users/invite`), and associated schemas:
+  - ManagementProjectsUserInviteCreateRequestBody
+  - ManagementProjectsUserInviteParameters
+- Added the ManagementProjectsSideKeys schema for app ID and app token in the server-side and client-side objects, which are returned in the **POST** `/management/v1/projects/` endpoint
+
 ## 2024-07-10
 
 `OpenAPI.json`:

--- a/docs/reference-docs/MANAGEMENT-Invite-User.md
+++ b/docs/reference-docs/MANAGEMENT-Invite-User.md
@@ -1,0 +1,14 @@
+---
+title: Invite a New User [Beta]
+type: endpoint
+categorySlug: voucherify-api
+slug: invite-user
+parentDocSlug: management
+hidden: false
+order: 55
+---
+[block:html]
+{
+  "html": "<style>\n[title=\"Toggle library\"] { \n  display: none; }\n.LanguagePicker-divider { \n  display: none; }\n.Playground-section3VTXuaYZivJK > .APISectionHeader3LN_-QIR0m7x {\n  display: none; }\n.LanguagePicker-languages1qVVo_v6AlP9 {\n  display: none; }\nh1::after {\n content: \"BETA\";\n background-color: rgb(237, 117, 71);\n color: rgb(255, 255, 255);\n border-radius: 2rem;padding: 8px 13px 8px;\n white-space: nowrap;font-size:12px;\n}</style>"
+}
+[/block]

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -40906,6 +40906,47 @@
           "is_owner"
         ]
       },
+      "ManagementProjectsUserInviteCreateRequestBody": {
+        "type": "object",
+        "description": "Request body schema for **POST** `/management/v1/projects/users/invite`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ManagementProjectsUserInviteParameters"
+          }
+        ]
+      },
+      "ManagementProjectsUserInviteParameters": {
+        "type": "object",
+        "title": "",
+        "description": "",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": ""
+          },
+          "first_name": {
+            "type": "string",
+            "description": ""
+          },
+          "last_name": {
+            "type": "string",
+            "description": ""
+          },
+          "projects": {
+            "type": "objects",
+            "description": "",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "projects"
+        ]
+      },
       "ManagementProjectsStackingRulesCreateRequestBody": {
         "type": "object",
         "description": "",
@@ -82692,6 +82733,201 @@
                       "request_id": "v-0e9a1b4b98c0a98ffc",
                       "resource_id": "user_VNBwrq3d4OaxJjoykkwIRTbqgnYgjCl",
                       "resource_type": "user"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/management/v1/projects/users/invite": {
+      "parameters": [],
+      "post": {
+        "operationId": "invite-user",
+        "tags": [
+          "Management"
+        ],
+        "summary": "Invite a New Voucherify User",
+        "description": "Sends an invitation to an email address of a person who is not a Voucherify user.\n\nYou can specify the projects to which the person will be assigned and define their roles.",
+        "parameters": [],
+        "security": [
+          {
+            "X-Management-Id": [],
+            "X-Management-Token": []
+          }
+        ],
+        "requestBody": {
+          "description": "Defines the details of the invitation and the project and roles to which the person will be assigned.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagementProjectsUserInviteCreateRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Returns no content if the invitation has been sent successfully."
+          },
+          "400": {
+            "description": "Returns an error if the payload includes all three keys or the required data is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/e_400_invalid_payload"
+                },
+                "examples": {
+                  "Invalid payload": {
+                    "value": {
+                      "code": 400,
+                      "key": "invalid_payload",
+                      "message": "Invalid payload",
+                      "details": "Payload must have required property 'name'",
+                      "request_id": "v-0e9389ccac8da56f55"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Returns an error if an invalid token was provided.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": 401,
+                      "message": "Unauthorized",
+                      "key": "unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Returns an error if the current plan does not include the Management API feature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorPaymentRequired"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "code": 402,
+                      "message": "Payment required",
+                      "details": "Your current plan does not include a feature required to perform this operation.",
+                      "key": "missing_required_feature"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "list-users",
+        "tags": [
+          "Management"
+        ],
+        "summary": "List Users",
+        "description": "Lists all users assigned to the project.",
+        "parameters": [],
+        "security": [
+          {
+            "X-Management-Id": [],
+            "X-Management-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of all the users assigned to the project.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementProjectsUserListResponseBody"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "object": "list",
+                      "data_ref": "data",
+                      "data": [
+                        {
+                          "id": "user_FgEAjOw6riObJdy81s2yZXdqZNiAV1pM",
+                          "login": "name@youremaildomain.com",
+                          "email": "name@youremaildomain.com",
+                          "first_name": "Sammy",
+                          "last_name": "Jones",
+                          "projects": {
+                            "proj_9KeAhZB1": "USER",
+                            "proj_npnFzPr9": "USER",
+                            "proj_pEP3NO9s": "USER",
+                            "proj_zsPdrUIw": "ADMIN"
+                          },
+                          "is_owner": false
+                        },
+                        {
+                          "id": "user_11sYvPrOj3XE573FO1cAzzk1p4k92wLL",
+                          "login": "name@youremaildomain.com",
+                          "email": "name@youremaildomain.com",
+                          "first_name": "Alex",
+                          "last_name": "Smith",
+                          "projects": {
+                            "proj_3CNHbOe0": "ADMIN"
+                          },
+                          "is_owner": true
+                        }
+                      ],
+                      "total": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Returns an error if an invalid token was provided.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": 401,
+                      "message": "Unauthorized",
+                      "key": "unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Returns an error if the current plan does not include the Management API feature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorPaymentRequired"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "code": 402,
+                      "message": "Payment required",
+                      "details": "Your current plan does not include a feature required to perform this operation.",
+                      "key": "missing_required_feature"
                     }
                   }
                 }

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -40884,7 +40884,7 @@
           },
           "projects": {
             "type": "object",
-            "description": "Lists key-value pairs, where the key is the project to which the user is assigned. The value is the role assigned in a given project.",
+            "description": "Lists key-value pairs, where the key is the project to which the user is assigned. The value is the role assigned in a given project. The predefined Voucherify roles are: `ADMIN`, `USER`, `VIEWER`, `MERCHANT`, `USER_RESTRICTED`",
             "additionalProperties": {
               "type": "string",
               "description": "Returns the role the user has in the project."
@@ -40933,10 +40933,13 @@
             "description": ""
           },
           "projects": {
-            "type": "objects",
-            "description": "",
-            "items": {
-              "type": "string"
+            "type": "object",
+            "title": "Project and Role",
+            "description": "In the key, provide the project ID to which the new user should be assigned. In the value, provide the role the user should have in the project. The predefined Voucherify roles are: `ADMIN`, `USER`, `VIEWER`, `MERCHANT`, `USER_RESTRICTED`. You can use also custom roles.",
+            "additionalProperties": {
+              "type": "string",
+              "title": "Project",
+              "description": "Defines the project to which the user will be assigned and the role in the project"
             }
           }
         },
@@ -82787,108 +82790,6 @@
                       "message": "Invalid payload",
                       "details": "Payload must have required property 'name'",
                       "request_id": "v-0e9389ccac8da56f55"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Returns an error if an invalid token was provided.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "Unauthorized": {
-                    "value": {
-                      "code": 401,
-                      "message": "Unauthorized",
-                      "key": "unauthorized"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Returns an error if the current plan does not include the Management API feature.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorPaymentRequired"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "code": 402,
-                      "message": "Payment required",
-                      "details": "Your current plan does not include a feature required to perform this operation.",
-                      "key": "missing_required_feature"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "list-users",
-        "tags": [
-          "Management"
-        ],
-        "summary": "List Users",
-        "description": "Lists all users assigned to the project.",
-        "parameters": [],
-        "security": [
-          {
-            "X-Management-Id": [],
-            "X-Management-Token": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the list of all the users assigned to the project.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ManagementProjectsUserListResponseBody"
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "object": "list",
-                      "data_ref": "data",
-                      "data": [
-                        {
-                          "id": "user_FgEAjOw6riObJdy81s2yZXdqZNiAV1pM",
-                          "login": "name@youremaildomain.com",
-                          "email": "name@youremaildomain.com",
-                          "first_name": "Sammy",
-                          "last_name": "Jones",
-                          "projects": {
-                            "proj_9KeAhZB1": "USER",
-                            "proj_npnFzPr9": "USER",
-                            "proj_pEP3NO9s": "USER",
-                            "proj_zsPdrUIw": "ADMIN"
-                          },
-                          "is_owner": false
-                        },
-                        {
-                          "id": "user_11sYvPrOj3XE573FO1cAzzk1p4k92wLL",
-                          "login": "name@youremaildomain.com",
-                          "email": "name@youremaildomain.com",
-                          "first_name": "Alex",
-                          "last_name": "Smith",
-                          "projects": {
-                            "proj_3CNHbOe0": "ADMIN"
-                          },
-                          "is_owner": true
-                        }
-                      ],
-                      "total": 2
                     }
                   }
                 }

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -40674,6 +40674,9 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/ManagementProjectsResponseBase"
+          },
+          {
+            "$ref": "#/components/schemas/ManagementProjectsSideKeys"
           }
         ]
       },
@@ -40772,6 +40775,47 @@
         "required": [
           "default_code_config"
         ]
+      },
+      "ManagementProjectsSideKeys": {
+        "type": "object",
+        "title": "Project and Side Keys",
+        "description": "Returns `app_id` and `app_token` for the server-side and client-side authentication.",
+        "properties": {
+          "server_side_key": {
+            "type": "object",
+            "title": "`server_side_key`",
+            "description": "Contains the `app_id` and `app_token` to authenticate server-side requests.",
+            "properties": {
+              "app_id": {
+                "type": "string",
+                "title": "`app_id`",
+                "description": "Application ID to be used as `X-App-Id` header in every HTTP request."
+              },
+              "app_token": {
+                "type": "string",
+                "title": "`app_token`",
+                "description": "Application token to be used as `X-App-Token` header in every HTTP request.\n\nThe application token (secret key) for the server-side authentication is visible in the Project Settings for 14 days when it is first generated in a newly-created project. Write your application token down and keep it in a safe place."
+              }
+            }
+          },
+          "client_side_key": {
+            "type": "object",
+            "title": "`client_side_key`",
+            "description": "Contains the `app_id` and `app_token` to authenticate client-side requests.",
+            "properties": {
+              "app_id": {
+                "type": "string",
+                "title": "`app_id`",
+                "description": "Application ID to be used as `X-App-Id` header in every HTTP request."
+              },
+              "app_token": {
+                "type": "string",
+                "title": "`app_token`",
+                "description": "Application token to be used as `X-App-Token` header in every HTTP request.\n\nThe application token (secret key) for the client-side authentication is visible in the Project Settings for 14 days when it is first generated in a newly-created project. Write your application token down and keep it in a safe place."
+              }
+            }
+          }
+        }
       },
       "ManagementProjectsUserCreateRequestBody": {
         "type": "object",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -40917,29 +40917,35 @@
       },
       "ManagementProjectsUserInviteParameters": {
         "type": "object",
-        "title": "",
-        "description": "",
+        "title": "New User Invitation Parameters",
+        "description": "Invite a new user to Voucherify and assign projects and roles to them.",
         "properties": {
           "email": {
             "type": "string",
-            "description": ""
+            "description": "Email address to which the invitation will be sent. Must be a valid email address.",
+            "example": "alex.doe@your-domain-name.com"
           },
           "first_name": {
             "type": "string",
-            "description": ""
+            "description": "First name of the person who will receive the invitation. The name will be used in the user profile.",
+            "example": "Alex"
           },
           "last_name": {
             "type": "string",
-            "description": ""
+            "description": "Last name of the person who will receive the invitation. The name will be used in the user profile.",
+            "example": "Doe"
           },
           "projects": {
             "type": "object",
             "title": "Project and Role",
-            "description": "In the key, provide the project ID to which the new user should be assigned. In the value, provide the role the user should have in the project. The predefined Voucherify roles are: `ADMIN`, `USER`, `VIEWER`, `MERCHANT`, `USER_RESTRICTED`. You can use also custom roles.",
+            "description": "In the key, provide the project ID to which the new user will be assigned. In the value, provide the role which the user will have in the project. The predefined Voucherify roles are: `ADMIN`, `USER`, `VIEWER`, `MERCHANT`, `USER_RESTRICTED`. Send a custom role ID (Enterprise feature) to assign a custom role.",
             "additionalProperties": {
               "type": "string",
-              "title": "Project",
-              "description": "Defines the project to which the user will be assigned and the role in the project"
+              "title": "project_id",
+              "description": "Defines the project to which the user will be assigned and the role in the project."
+            },
+            "example": {
+              "proj_ExPr0jID": "USER"
             }
           }
         },
@@ -82752,8 +82758,8 @@
         "tags": [
           "Management"
         ],
-        "summary": "Invite a New Voucherify User",
-        "description": "Sends an invitation to an email address of a person who is not a Voucherify user.\n\nYou can specify the projects to which the person will be assigned and define their roles.",
+        "summary": "Invite a New User",
+        "description": "Sends an invitation to an email address that has not been used yet as a Voucherify user login.\n\nYou can specify the projects to which the invited user will be assigned and define their roles.",
         "parameters": [],
         "security": [
           {
@@ -82762,7 +82768,7 @@
           }
         ],
         "requestBody": {
-          "description": "Defines the details of the invitation and the project and roles to which the person will be assigned.",
+          "description": "Defines the details of the invitation, the project, and roles to which the user will be assigned.",
           "content": {
             "application/json": {
               "schema": {
@@ -82776,7 +82782,7 @@
             "description": "Returns no content if the invitation has been sent successfully."
           },
           "400": {
-            "description": "Returns an error if the payload includes all three keys or the required data is missing.",
+            "description": "Returns an error if the payload includes an incorrect role.",
             "content": {
               "application/json": {
                 "schema": {
@@ -82786,49 +82792,55 @@
                   "Invalid payload": {
                     "value": {
                       "code": 400,
-                      "key": "invalid_payload",
-                      "message": "Invalid payload",
-                      "details": "Payload must have required property 'name'",
-                      "request_id": "v-0e9389ccac8da56f55"
+                      "key": "used_incorrect_role",
+                      "message": "Used incorrect role",
+                      "details": "The role 'VICE_ADMIN' is incorrect",
+                      "request_id": "v-0f0f63a9f00cdbd981"
                     }
                   }
                 }
               }
             }
           },
-          "401": {
-            "description": "Returns an error if an invalid token was provided.",
+          "404": {
+            "description": "Returns an error if the project does not exist or has been deleted.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error"
                 },
                 "examples": {
-                  "Unauthorized": {
+                  "Not Found": {
                     "value": {
-                      "code": 401,
-                      "message": "Unauthorized",
-                      "key": "unauthorized"
+                      "code": 404,
+                      "key": "not_found",
+                      "message": "Resource not found",
+                      "details": "Cannot find project with id proj_4r3Ul0St",
+                      "request_id": "v-0f0f62fe19ccdbd8bc",
+                      "resource_id": "proj_4r3Ul0St",
+                      "resource_type": "project"
                     }
                   }
                 }
               }
             }
           },
-          "402": {
-            "description": "Returns an error if the current plan does not include the Management API feature.",
+          "409": {
+            "description": "Returns an error if the email address belongs to a Voucherify user.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorPaymentRequired"
+                  "$ref": "#/components/schemas/Error"
                 },
                 "examples": {
-                  "Example": {
+                  "Duplicate Code": {
                     "value": {
-                      "code": 402,
-                      "message": "Payment required",
-                      "details": "Your current plan does not include a feature required to perform this operation.",
-                      "key": "missing_required_feature"
+                      "code": 409,
+                      "key": "duplicate_found",
+                      "message": "Duplicated resource found",
+                      "details": "Duplicated user exists with email your.email@domain.com",
+                      "resource_id": "your.email@domain.com",
+                      "resource_type": "user"
                     }
                   }
                 }


### PR DESCRIPTION
## What

- Added an endpoint to invite a new Voucherify user to project(s) and assign role(s).
- Return server-side and client-side tokens for the **POST** `/management/v1/projects/` endpoint.

## How

Invite user endpoint:
- No `enum` with the roles in the `projects` object, because custom roles are allowed there.

Added associated schemas to the invite user endpoint and the create project endpoint.