### PR TITLE
Application rules – updates

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,18 @@
 
 Older changes in [DEPRECATED.md](deprecated/DEPRECATED.md)
 
+## 2024-09-12
+
+Added the descriptions to the following fields in the `ApplicableTo` schema:
+- `order_item_indices`
+- `repeat`
+- `skip_initially`
+- `target`
+
+Added two new effects to the `enum` in `ApplicableToEffect` schema:
+- `APPLY_FROM_CHEAPEST`
+- `APPLY_FROM_MOST_EXPENSIVE`
+
 ## 2024-09-06
 
 `OpenAPI.json` and `OpenAPIWebhooks.json` - removed references to consent feature; removed among others:

--- a/docs/reference-docs/CUSTOMERS-Customer-Activity-Object.md
+++ b/docs/reference-docs/CUSTOMERS-Customer-Activity-Object.md
@@ -1590,9 +1590,9 @@ One of:
 ## Applicable To
 | Attributes |  Description |
 |:-----|:--------|
-| object</br>`string` | <p>This object stores information about the product collection.</p> Available values: `product`, `sku`, `products_collection` |
-| id</br>`string` | <p>Unique product collection ID assigned by Voucherify.</p> |
-| source_id</br>`string` | <p>The source ID from your inventory system.</p> |
+| object</br>`string` | <p>This object stores information about the resource to which the discount is applicable.</p> Available values: `product`, `sku`, `products_collection` |
+| id</br>`string` | <p>Unique product collection, product, or SKU identifier assigned by Voucherify.</p> |
+| source_id</br>`string` | <p>The source identifier from your inventory system.</p> |
 | product_id</br>`string` | <p>Parent product's unique ID assigned by Voucherify.</p> |
 | product_source_id</br>`string` | <p>Parent product's source ID from your inventory system.</p> |
 | strict</br>`boolean` |  |
@@ -1603,10 +1603,10 @@ One of:
 | aggregated_quantity_limit</br>`integer` | <p>The maximum number of units allowed to be discounted combined across all matched order line items.</p> |
 | amount_limit</br>`integer` | <p>Upper limit allowed to be applied as a discount per order line item. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount is written as 600.</p> |
 | aggregated_amount_limit</br>`integer` | <p>Maximum discount amount per order. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount on the entire order is written as 600. This value is definable for the following discount effects:</p><ul><li><code>APPLY_TO_ITEMS</code> (each item subtotal is discounted equally)</li><li><code>APPLY_TO_ITEMS_BY_QUANTITY</code> (each unit of matched products has the same discount value)</li></ul> |
-| order_item_indices</br>`array` |  |
-| repeat</br>`integer` |  |
-| skip_initially</br>`integer` |  |
-| target</br>`string` |  |
+| order_item_indices</br>`array` | <p>Determines the order in which the discount is applied to the products or SKUs sent in the <code>order</code> object in the request. The counting begins from <code>0</code>.</p> |
+| repeat</br>`integer` | <p>Determines the recurrence of the discount, e.g. <code>&quot;repeat&quot;: 3</code> means that the discount is applied to every third item.</p> |
+| skip_initially</br>`integer` | <p>Determines how many items are skipped before the discount is applied.</p> |
+| target</br>`string` | <p>Determines to which kinds of objects the discount is applicable. <code>&quot;ITEM&quot;</code> includes products and SKUs.</p> Available values: `ITEM` |
 
 ## Inapplicable To
 [Applicable To](#applicable-to)
@@ -1654,7 +1654,7 @@ One of:
 | order_items</br>`object` | <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">subtotal_amount</br><code>object</code></td><td style="text-align:left"><p>Defines the ratio based on the property defined in the calculation_type parameter. For every set of value (1, 10, etc) defined in the every parameter for the property defined in calculation_type, give the customer the number of points defined in the points parameter. In other words, for every calculation_type, give points.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">every</br><code>integer</code></td><td style="text-align:left"><p>Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $10 order amount is written as 1000.</p></td></tr><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Number of points to be awarded, i.e. how many points to be added to the loyalty card.</p></td></tr><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>Type of object taken under consideration.</p> Available values: <code>products_collection</code>, <code>product</code>, <code>sku</code></td></tr><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique ID of the resource, i.e. pc_75U0dHlr7u75BJodrW1AE3t6, prod_0bae32322150fd0546, or sku_0b7d7dfb090be5c619.</p></td></tr></tbody></table></td></tr></tbody></table> |
 
 ## Applicable To Effect
-Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`
+Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_FROM_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`, `APPLY_FROM_MOST_EXPENSIVE`
 
 [block:html]
 {

--- a/docs/reference-docs/QUALIFICATIONS-Qualification-Object.md
+++ b/docs/reference-docs/QUALIFICATIONS-Qualification-Object.md
@@ -221,9 +221,9 @@ One of:
 ## Applicable To
 | Attributes |  Description |
 |:-----|:--------|
-| object</br>`string` | <p>This object stores information about the product collection.</p> Available values: `product`, `sku`, `products_collection` |
-| id</br>`string` | <p>Unique product collection ID assigned by Voucherify.</p> |
-| source_id</br>`string` | <p>The source ID from your inventory system.</p> |
+| object</br>`string` | <p>This object stores information about the resource to which the discount is applicable.</p> Available values: `product`, `sku`, `products_collection` |
+| id</br>`string` | <p>Unique product collection, product, or SKU identifier assigned by Voucherify.</p> |
+| source_id</br>`string` | <p>The source identifier from your inventory system.</p> |
 | product_id</br>`string` | <p>Parent product's unique ID assigned by Voucherify.</p> |
 | product_source_id</br>`string` | <p>Parent product's source ID from your inventory system.</p> |
 | strict</br>`boolean` |  |
@@ -234,10 +234,10 @@ One of:
 | aggregated_quantity_limit</br>`integer` | <p>The maximum number of units allowed to be discounted combined across all matched order line items.</p> |
 | amount_limit</br>`integer` | <p>Upper limit allowed to be applied as a discount per order line item. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount is written as 600.</p> |
 | aggregated_amount_limit</br>`integer` | <p>Maximum discount amount per order. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount on the entire order is written as 600. This value is definable for the following discount effects:</p><ul><li><code>APPLY_TO_ITEMS</code> (each item subtotal is discounted equally)</li><li><code>APPLY_TO_ITEMS_BY_QUANTITY</code> (each unit of matched products has the same discount value)</li></ul> |
-| order_item_indices</br>`array` |  |
-| repeat</br>`integer` |  |
-| skip_initially</br>`integer` |  |
-| target</br>`string` |  |
+| order_item_indices</br>`array` | <p>Determines the order in which the discount is applied to the products or SKUs sent in the <code>order</code> object in the request. The counting begins from <code>0</code>.</p> |
+| repeat</br>`integer` | <p>Determines the recurrence of the discount, e.g. <code>&quot;repeat&quot;: 3</code> means that the discount is applied to every third item.</p> |
+| skip_initially</br>`integer` | <p>Determines how many items are skipped before the discount is applied.</p> |
+| target</br>`string` | <p>Determines to which kinds of objects the discount is applicable. <code>&quot;ITEM&quot;</code> includes products and SKUs.</p> Available values: `ITEM` |
 
 ## Inapplicable To
 [Applicable To](#applicable-to)
@@ -313,7 +313,7 @@ One of:
 | source_id</br>`string` | <p>The merchant's transaction ID if it is different from the Voucherify transaction ID. It is really useful in case of an integration between multiple systems. It can be a transaction ID from a CRM system, database or 3rd-party service.</p> |
 
 ## Applicable To Effect
-Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`
+Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_FROM_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`, `APPLY_FROM_MOST_EXPENSIVE`
 
 ## Discount Amount Vouchers Effect Types
 Available values: `APPLY_TO_ORDER`, `APPLY_TO_ITEMS`, `APPLY_TO_ITEMS_PROPORTIONALLY`, `APPLY_TO_ITEMS_PROPORTIONALLY_BY_QUANTITY`, `APPLY_TO_ITEMS_BY_QUANTITY`

--- a/docs/reference-docs/VALIDATION-RULES-Validation-Rule-Object.md
+++ b/docs/reference-docs/VALIDATION-RULES-Validation-Rule-Object.md
@@ -33,9 +33,9 @@ All of:
 ## Applicable To
 | Attributes |  Description |
 |:-----|:--------|
-| object</br>`string` | <p>This object stores information about the product collection.</p> Available values: `product`, `sku`, `products_collection` |
-| id</br>`string` | <p>Unique product collection ID assigned by Voucherify.</p> |
-| source_id</br>`string` | <p>The source ID from your inventory system.</p> |
+| object</br>`string` | <p>This object stores information about the resource to which the discount is applicable.</p> Available values: `product`, `sku`, `products_collection` |
+| id</br>`string` | <p>Unique product collection, product, or SKU identifier assigned by Voucherify.</p> |
+| source_id</br>`string` | <p>The source identifier from your inventory system.</p> |
 | product_id</br>`string` | <p>Parent product's unique ID assigned by Voucherify.</p> |
 | product_source_id</br>`string` | <p>Parent product's source ID from your inventory system.</p> |
 | strict</br>`boolean` |  |
@@ -46,10 +46,10 @@ All of:
 | aggregated_quantity_limit</br>`integer` | <p>The maximum number of units allowed to be discounted combined across all matched order line items.</p> |
 | amount_limit</br>`integer` | <p>Upper limit allowed to be applied as a discount per order line item. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount is written as 600.</p> |
 | aggregated_amount_limit</br>`integer` | <p>Maximum discount amount per order. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount on the entire order is written as 600. This value is definable for the following discount effects:</p><ul><li><code>APPLY_TO_ITEMS</code> (each item subtotal is discounted equally)</li><li><code>APPLY_TO_ITEMS_BY_QUANTITY</code> (each unit of matched products has the same discount value)</li></ul> |
-| order_item_indices</br>`array` |  |
-| repeat</br>`integer` |  |
-| skip_initially</br>`integer` |  |
-| target</br>`string` |  |
+| order_item_indices</br>`array` | <p>Determines the order in which the discount is applied to the products or SKUs sent in the <code>order</code> object in the request. The counting begins from <code>0</code>.</p> |
+| repeat</br>`integer` | <p>Determines the recurrence of the discount, e.g. <code>&quot;repeat&quot;: 3</code> means that the discount is applied to every third item.</p> |
+| skip_initially</br>`integer` | <p>Determines how many items are skipped before the discount is applied.</p> |
+| target</br>`string` | <p>Determines to which kinds of objects the discount is applicable. <code>&quot;ITEM&quot;</code> includes products and SKUs.</p> Available values: `ITEM` |
 
 ## Validation Rule Conditions
 | Attributes |  Description |
@@ -76,7 +76,7 @@ All of:
 | $not_intersect</br>`array` | Array any of: string, number, object |
 
 ## Applicable To Effect
-Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`
+Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_FROM_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`, `APPLY_FROM_MOST_EXPENSIVE`
 
 ## Any
 One of:

--- a/docs/reference-docs/VALIDATIONS-Validation-Object.md
+++ b/docs/reference-docs/VALIDATIONS-Validation-Object.md
@@ -113,9 +113,9 @@ One of:
 ## Applicable To
 | Attributes |  Description |
 |:-----|:--------|
-| object</br>`string` | <p>This object stores information about the product collection.</p> Available values: `product`, `sku`, `products_collection` |
-| id</br>`string` | <p>Unique product collection ID assigned by Voucherify.</p> |
-| source_id</br>`string` | <p>The source ID from your inventory system.</p> |
+| object</br>`string` | <p>This object stores information about the resource to which the discount is applicable.</p> Available values: `product`, `sku`, `products_collection` |
+| id</br>`string` | <p>Unique product collection, product, or SKU identifier assigned by Voucherify.</p> |
+| source_id</br>`string` | <p>The source identifier from your inventory system.</p> |
 | product_id</br>`string` | <p>Parent product's unique ID assigned by Voucherify.</p> |
 | product_source_id</br>`string` | <p>Parent product's source ID from your inventory system.</p> |
 | strict</br>`boolean` |  |
@@ -126,10 +126,10 @@ One of:
 | aggregated_quantity_limit</br>`integer` | <p>The maximum number of units allowed to be discounted combined across all matched order line items.</p> |
 | amount_limit</br>`integer` | <p>Upper limit allowed to be applied as a discount per order line item. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount is written as 600.</p> |
 | aggregated_amount_limit</br>`integer` | <p>Maximum discount amount per order. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount on the entire order is written as 600. This value is definable for the following discount effects:</p><ul><li><code>APPLY_TO_ITEMS</code> (each item subtotal is discounted equally)</li><li><code>APPLY_TO_ITEMS_BY_QUANTITY</code> (each unit of matched products has the same discount value)</li></ul> |
-| order_item_indices</br>`array` |  |
-| repeat</br>`integer` |  |
-| skip_initially</br>`integer` |  |
-| target</br>`string` |  |
+| order_item_indices</br>`array` | <p>Determines the order in which the discount is applied to the products or SKUs sent in the <code>order</code> object in the request. The counting begins from <code>0</code>.</p> |
+| repeat</br>`integer` | <p>Determines the recurrence of the discount, e.g. <code>&quot;repeat&quot;: 3</code> means that the discount is applied to every third item.</p> |
+| skip_initially</br>`integer` | <p>Determines how many items are skipped before the discount is applied.</p> |
+| target</br>`string` | <p>Determines to which kinds of objects the discount is applicable. <code>&quot;ITEM&quot;</code> includes products and SKUs.</p> Available values: `ITEM` |
 
 ## Inapplicable To
 [Applicable To](#applicable-to)
@@ -230,7 +230,7 @@ One of:
 | rollback_stacked</br>`array` | <p>Lists the rollback redemption IDs of the particular child redemptions.</p> |
 
 ## Applicable To Effect
-Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`
+Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_FROM_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`, `APPLY_FROM_MOST_EXPENSIVE`
 
 ## Discount Amount Vouchers Effect Types
 Available values: `APPLY_TO_ORDER`, `APPLY_TO_ITEMS`, `APPLY_TO_ITEMS_PROPORTIONALLY`, `APPLY_TO_ITEMS_PROPORTIONALLY_BY_QUANTITY`, `APPLY_TO_ITEMS_BY_QUANTITY`

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -880,17 +880,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -947,6 +947,7 @@
           },
           "order_item_indices": {
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "type": "integer"
             },
@@ -954,14 +955,20 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },
@@ -975,7 +982,9 @@
         "enum": [
           "APPLY_TO_EVERY",
           "APPLY_TO_CHEAPEST",
-          "APPLY_TO_MOST_EXPENSIVE"
+          "APPLY_FROM_CHEAPEST",
+          "APPLY_TO_MOST_EXPENSIVE",
+          "APPLY_FROM_MOST_EXPENSIVE"
         ]
       },
       "ApplicableToResultList": {

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -37410,15 +37410,15 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection."
+            "description": "This object stores information about the resource to which the discount is applicable."
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify."
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify."
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system."
+            "description": "The source identifier from your inventory system."
           },
           "product_id": {
             "type": "string",
@@ -37465,18 +37465,25 @@
           },
           "order_item_indices": {
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "type": "integer"
             }
           },
           "repeat": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item."
           },
           "skip_initially": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied."
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "enum": [
+              "ITEM"
+            ]
           }
         },
         "required": [
@@ -37492,7 +37499,9 @@
         "enum": [
           "APPLY_TO_EVERY",
           "APPLY_TO_CHEAPEST",
-          "APPLY_TO_MOST_EXPENSIVE"
+          "APPLY_FROM_CHEAPEST",
+          "APPLY_TO_MOST_EXPENSIVE",
+          "APPLY_FROM_MOST_EXPENSIVE"
         ]
       },
       "VouchersValidateResponseBody": {

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -22971,17 +22971,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -23034,6 +23034,7 @@
           "order_item_indices": {
             "title": "ApplicableToOrderItemIndices",
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "title": "ApplicableToOrderItemIndicesItem",
               "type": "integer"
@@ -23042,14 +23043,21 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "default": "ITEM",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },
@@ -32365,7 +32373,9 @@
         "enum": [
           "APPLY_TO_EVERY",
           "APPLY_TO_CHEAPEST",
-          "APPLY_TO_MOST_EXPENSIVE"
+          "APPLY_FROM_CHEAPEST",
+          "APPLY_TO_MOST_EXPENSIVE",
+          "APPLY_FROM_MOST_EXPENSIVE"
         ]
       },
       "AreaStoreCampaignAssignment": {
@@ -32694,17 +32704,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -32757,6 +32767,7 @@
           "order_item_indices": {
             "title": "InapplicableToOrderItemIndices",
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "title": "InapplicableToOrderItemIndicesItem",
               "type": "integer"
@@ -32765,14 +32776,21 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "default": "ITEM",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -24018,17 +24018,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -24060,7 +24060,9 @@
             "enum": [
               "APPLY_TO_EVERY",
               "APPLY_TO_CHEAPEST",
-              "APPLY_TO_MOST_EXPENSIVE"
+              "APPLY_FROM_CHEAPEST",
+              "APPLY_TO_MOST_EXPENSIVE",
+              "APPLY_FROM_MOST_EXPENSIVE"
             ],
             "nullable": true
           },
@@ -24087,6 +24089,7 @@
           "order_item_indices": {
             "title": "ApplicableToOrderItemIndices",
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "title": "ApplicableToOrderItemIndicesItem",
               "type": "integer"
@@ -24095,14 +24098,21 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "default": "ITEM",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },
@@ -34028,17 +34038,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -34070,7 +34080,9 @@
             "enum": [
               "APPLY_TO_EVERY",
               "APPLY_TO_CHEAPEST",
-              "APPLY_TO_MOST_EXPENSIVE"
+              "APPLY_FROM_CHEAPEST",
+              "APPLY_TO_MOST_EXPENSIVE",
+              "APPLY_FROM_MOST_EXPENSIVE"
             ],
             "nullable": true
           },
@@ -34097,6 +34109,7 @@
           "order_item_indices": {
             "title": "InapplicableToOrderItemIndices",
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "title": "InapplicableToOrderItemIndicesItem",
               "type": "integer"
@@ -34105,14 +34118,21 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "default": "ITEM",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -23005,17 +23005,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -23068,6 +23068,7 @@
           "order_item_indices": {
             "title": "ApplicableToOrderItemIndices",
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "title": "ApplicableToOrderItemIndicesItem",
               "type": "integer"
@@ -23076,14 +23077,21 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "default": "ITEM",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },
@@ -32399,7 +32407,9 @@
         "enum": [
           "APPLY_TO_EVERY",
           "APPLY_TO_CHEAPEST",
-          "APPLY_TO_MOST_EXPENSIVE"
+          "APPLY_FROM_CHEAPEST",
+          "APPLY_TO_MOST_EXPENSIVE",
+          "APPLY_FROM_MOST_EXPENSIVE"
         ]
       },
       "AreaStoreCampaignAssignment": {
@@ -32728,17 +32738,17 @@
               "sku",
               "products_collection"
             ],
-            "description": "This object stores information about the product collection.",
+            "description": "This object stores information about the resource to which the discount is applicable.",
             "nullable": true
           },
           "id": {
             "type": "string",
-            "description": "Unique product collection ID assigned by Voucherify.",
+            "description": "Unique product collection, product, or SKU identifier assigned by Voucherify.",
             "nullable": true
           },
           "source_id": {
             "type": "string",
-            "description": "The source ID from your inventory system.",
+            "description": "The source identifier from your inventory system.",
             "nullable": true
           },
           "product_id": {
@@ -32791,6 +32801,7 @@
           "order_item_indices": {
             "title": "InapplicableToOrderItemIndices",
             "type": "array",
+            "description": "Determines the order in which the discount is applied to the products or SKUs sent in the `order` object in the request. The counting begins from `0`.",
             "items": {
               "title": "InapplicableToOrderItemIndicesItem",
               "type": "integer"
@@ -32799,14 +32810,21 @@
           },
           "repeat": {
             "type": "integer",
+            "description": "Determines the recurrence of the discount, e.g. `\"repeat\": 3` means that the discount is applied to every third item.",
             "nullable": true
           },
           "skip_initially": {
             "type": "integer",
+            "description": "Determines how many items are skipped before the discount is applied.",
             "nullable": true
           },
           "target": {
             "type": "string",
+            "description": "Determines to which kinds of objects the discount is applicable. `\"ITEM\"` includes products and SKUs.",
+            "default": "ITEM",
+            "enum": [
+              "ITEM"
+            ],
             "nullable": true
           }
         },


### PR DESCRIPTION
Added the descriptions to the following fields in the `ApplicableTo` schema:
- `order_item_indices`
- `repeat`
- `skip_initially`
- `target`

Added two new effects to the `enum` in `ApplicableToEffect` schema:
- `APPLY_FROM_CHEAPEST`
- `APPLY_FROM_MOST_EXPENSIVE`