### PR TITLE
PW – `stacking_rules_type` fix quals and validations

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,10 @@
 
 Older changes in [DEPRECATED.md](deprecated/DEPRECATED.md)
 
+## 2024-10-21
+
+- Changes to POST `v1/qualifications` and POST `v1/validations` – only these endpoints should return `vouchers.categories.stacking_rules_type`
+
 ## 2024-10-11
 
 Changed the structure of the `ValidationRuleRules` schema. The recurrence of the schema caused performance issues with Readme pages that use the schema. Fixed by copying the schema and allowing 3 levels of nesting.

--- a/docs/reference-docs/CAMPAIGNS-Campaign-Object.md
+++ b/docs/reference-docs/CAMPAIGNS-Campaign-Object.md
@@ -112,7 +112,6 @@ All of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Referral Program
 | Attributes |  Description |

--- a/docs/reference-docs/CATEGORIES-Category-Object.md
+++ b/docs/reference-docs/CATEGORIES-Category-Object.md
@@ -17,7 +17,6 @@ order: 1
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 [block:html]
 {

--- a/docs/reference-docs/CUSTOMERS-Customer-Activity-Object.md
+++ b/docs/reference-docs/CUSTOMERS-Customer-Activity-Object.md
@@ -826,7 +826,6 @@ All of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Gift
 | Attributes |  Description |
@@ -1061,7 +1060,7 @@ Available values: `POINTS_ACCRUAL`, `POINTS_REDEMPTION`, `POINTS_REFUND`, `POINT
 | inapplicable_to | See: [Inapplicable To Result List](#inapplicable-to-result-list) |
 | result | <p>Specifies the redeemable's end effect on the order. This object is unique to each type of redeemable.</p> One of: [Coupon Code](#coupon-code), [Gift Card](#gift-card), [Loyalty Card](#loyalty-card), [Redeemable Result Promotion Tier](#redeemable-result-promotion-tier), [Promotion Stack](#promotion-stack) |
 | metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
+| categories</br>`array` | Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 
 ## Inapplicable Redeemable
 | Attributes |  Description |
@@ -1071,7 +1070,7 @@ Available values: `POINTS_ACCRUAL`, `POINTS_REDEMPTION`, `POINTS_REFUND`, `POINT
 | object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
 | result</br>`object` | <p>Includes the error object with details about the reason why the redeemable is inapplicable</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">error</td><td style="text-align:left">See: <a href="#error-object">Error Object</a></td></tr><tr><td style="text-align:left">details</br><code>object</code></td><td style="text-align:left"><p>Provides details about the reason why the redeemable is inapplicable.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">message</br><code>string</code></td><td style="text-align:left"><p>Generic message from the <code>message</code> string shown in the <code>error</code> object or the message configured in a validation rule.</p></td></tr><tr><td style="text-align:left">key</br><code>string</code></td><td style="text-align:left"><p>Generic message from the <code>key</code> string shown in the <code>error</code> object.</p></td></tr></tbody></table></td></tr></tbody></table> |
 | metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
+| categories</br>`array` | Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 
 ## Skipped Redeemable
 | Attributes |  Description |
@@ -1081,7 +1080,7 @@ Available values: `POINTS_ACCRUAL`, `POINTS_REDEMPTION`, `POINTS_REFUND`, `POINT
 | object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
 | result</br>`object` | <p>Provides details about the reason why the redeemable is skipped.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">details</td><td style="text-align:left">One of: <a href="#validations-redeemable-skipped-result-limit-exceeded">Validations Redeemable Skipped Result Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-category-limit-exceeded">Validations Redeemable Skipped Result Category Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-redeemables-limit-exceeded">Validations Redeemable Skipped Result Redeemables Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-redeemables-category-limit-exceeded">Validations Redeemable Skipped Result Redeemables Category Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-exclusion-rules-not-met">Validations Redeemable Skipped Result Exclusion Rules Not Met</a>, <a href="#validations-redeemable-skipped-result-preceding-validation-failed">Validations Redeemable Skipped Result Preceding Validation Failed</a></td></tr></tbody></table> |
 | metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
+| categories</br>`array` | Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 
 ## Simple Order
 | Attributes |  Description |
@@ -1372,6 +1371,14 @@ One of:
 | Attributes |  Description |
 |:-----|:--------|
 | loyalty_card</br>`object` | <p>Stores the amount of loyalty card points to be applied in the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Total number of loyalty points to be applied in the redemption.</p></td></tr></tbody></table> |
+
+## Category with Stacking Rules Type
+<p>Category object with <code>stacking_rules_type</code></p>
+
+All of:
+
+1. [Category](#category)
+2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">stacking_rules_type</br><code>string</code></td><td style="text-align:left"><p>The type of the stacking rule eligibility.</p> Available values: <code>JOINT</code>, <code>EXCLUSIVE</code></td></tr></tbody></table>
 
 ## Error Object
 | Attributes |  Description |

--- a/docs/reference-docs/LOYALTIES-Loyalty-Campaign-Object.md
+++ b/docs/reference-docs/LOYALTIES-Loyalty-Campaign-Object.md
@@ -80,7 +80,6 @@ order: 10
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Balance
 | Attributes |  Description |

--- a/docs/reference-docs/LOYALTIES-Loyalty-Card-Object.md
+++ b/docs/reference-docs/LOYALTIES-Loyalty-Card-Object.md
@@ -48,7 +48,6 @@ order: 20
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Validity Timeframe
 | Attributes |  Description |

--- a/docs/reference-docs/PROMOTIONS-Promotion-Tier-Object.md
+++ b/docs/reference-docs/PROMOTIONS-Promotion-Tier-Object.md
@@ -72,7 +72,6 @@ One of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Amount
 | Attributes |  Description |

--- a/docs/reference-docs/PUBLICATIONS-Publication-Object.md
+++ b/docs/reference-docs/PUBLICATIONS-Publication-Object.md
@@ -100,7 +100,6 @@ All of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Validation Rules Assignments List
 | Attributes |  Description |

--- a/docs/reference-docs/QUALIFICATIONS-Qualification-Object.md
+++ b/docs/reference-docs/QUALIFICATIONS-Qualification-Object.md
@@ -135,7 +135,7 @@ All of:
 | applicable_to | <p>Contains list of items that qualify in the scope of the discount. These are definitions of included products, SKUs, and product collections. These can be discounted.</p> [Applicable To Result List](#applicable-to-result-list) |
 | inapplicable_to | <p>Contains list of items that do not qualify in the scope of the discount. These are definitions of excluded products, SKUs, and product collections. These CANNOT be discounted.</p> [Inapplicable To Result List](#inapplicable-to-result-list) |
 | metadata</br>`object` | <p>The metadata object stores all custom attributes assigned to the product. A set of key/value pairs that you can attach to a product object. It can be useful for storing additional information about the product in a structured format.</p> |
-| categories</br>`array` | <p>List of category information.</p> Array of [Category](#category) |
+| categories</br>`array` | <p>List of category information.</p> Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 | banner</br>`string` | <p>Name of the earning rule. This is displayed as a header for the earning rule in the Dashboard.</p> **Example:** <p>Order Paid - You will get 100 points</p> |
 | name</br>`string` | <p>Name of the redeemable.</p> **Example:** <p>promotion_tier_get_points</p> |
 | campaign_name</br>`string` | <p>Name of the campaign associated to the redeemable. This field is available only if object is not <code>campaign</code></p> **Example:** <p>PromotionCampaign</p> |
@@ -166,16 +166,13 @@ All of:
 | object</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `list` |
 | data_ref</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `data` |
 
-## Category
-| Attributes |  Description |
-|:-----|:--------|
-| id</br>`string` | <p>Unique category ID assigned by Voucherify.</p> |
-| name</br>`string` | <p>Category name.</p> |
-| hierarchy</br>`integer` | <p>Category hierarchy.</p> |
-| object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
-| created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
-| updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
+## Category with Stacking Rules Type
+<p>Category object with <code>stacking_rules_type</code></p>
+
+All of:
+
+1. [Category](#category)
+2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">stacking_rules_type</br><code>string</code></td><td style="text-align:left"><p>The type of the stacking rule eligibility.</p> Available values: <code>JOINT</code>, <code>EXCLUSIVE</code></td></tr></tbody></table>
 
 ## Validation Rules Assignments List
 | Attributes |  Description |
@@ -241,6 +238,16 @@ One of:
 
 ## Inapplicable To
 [Applicable To](#applicable-to)
+
+## Category
+| Attributes |  Description |
+|:-----|:--------|
+| id</br>`string` | <p>Unique category ID assigned by Voucherify.</p> |
+| name</br>`string` | <p>Category name.</p> |
+| hierarchy</br>`integer` | <p>Category hierarchy.</p> |
+| object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
+| created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
+| updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
 
 ## Business Validation Rule Assignment
 | Attributes |  Description |

--- a/docs/reference-docs/REDEMPTIONS-Redemption-Object.md
+++ b/docs/reference-docs/REDEMPTIONS-Redemption-Object.md
@@ -79,7 +79,7 @@ order: 1
 | object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
 | result</br>`object` | <p>Includes the error object with details about the reason why the redeemable is inapplicable</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">error</td><td style="text-align:left">See: <a href="#error-object">Error Object</a></td></tr><tr><td style="text-align:left">details</br><code>object</code></td><td style="text-align:left"><p>Provides details about the reason why the redeemable is inapplicable.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">message</br><code>string</code></td><td style="text-align:left"><p>Generic message from the <code>message</code> string shown in the <code>error</code> object or the message configured in a validation rule.</p></td></tr><tr><td style="text-align:left">key</br><code>string</code></td><td style="text-align:left"><p>Generic message from the <code>key</code> string shown in the <code>error</code> object.</p></td></tr></tbody></table></td></tr></tbody></table> |
 | metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
+| categories</br>`array` | Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 
 ## Skipped Redeemable
 | Attributes |  Description |
@@ -89,7 +89,7 @@ order: 1
 | object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
 | result</br>`object` | <p>Provides details about the reason why the redeemable is skipped.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">details</td><td style="text-align:left">One of: <a href="#validations-redeemable-skipped-result-limit-exceeded">Validations Redeemable Skipped Result Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-category-limit-exceeded">Validations Redeemable Skipped Result Category Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-redeemables-limit-exceeded">Validations Redeemable Skipped Result Redeemables Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-redeemables-category-limit-exceeded">Validations Redeemable Skipped Result Redeemables Category Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-exclusion-rules-not-met">Validations Redeemable Skipped Result Exclusion Rules Not Met</a>, <a href="#validations-redeemable-skipped-result-preceding-validation-failed">Validations Redeemable Skipped Result Preceding Validation Failed</a></td></tr></tbody></table> |
 | metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
+| categories</br>`array` | Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 
 ## Simple Customer
 | Attributes |  Description |
@@ -215,16 +215,13 @@ All of:
 | resource_id</br>`string` | <p>Unique resource ID that can be used in another endpoint to get more details.</p> **Example:** <p>rf_0c5d710a87c8a31f86</p> |
 | resource_type</br>`string` | <p>The resource type.</p> **Example:** <p>voucher</p> |
 
-## Category
-| Attributes |  Description |
-|:-----|:--------|
-| id</br>`string` | <p>Unique category ID assigned by Voucherify.</p> |
-| name</br>`string` | <p>Category name.</p> |
-| hierarchy</br>`integer` | <p>Category hierarchy.</p> |
-| object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
-| created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
-| updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
+## Category with Stacking Rules Type
+<p>Category object with <code>stacking_rules_type</code></p>
+
+All of:
+
+1. [Category](#category)
+2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">stacking_rules_type</br><code>string</code></td><td style="text-align:left"><p>The type of the stacking rule eligibility.</p> Available values: <code>JOINT</code>, <code>EXCLUSIVE</code></td></tr></tbody></table>
 
 ## Validations Redeemable Skipped Result Limit Exceeded
 | Attributes |  Description |
@@ -292,6 +289,16 @@ All of:
 | object</br>`string` | <p>The type of the object represented by JSON. Default is <code>voucher</code>.</p> |
 | publish</br>`object` | <p>Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>The type of the object represented is by default <code>list</code>. To get this list, you need to make a call to the endpoint returned in the <code>url</code> attribute.</p></td></tr><tr><td style="text-align:left">count</br><code>integer</code></td><td style="text-align:left"><p>Publication events counter.</p> <strong>Example:</strong> <p>0</p></td></tr><tr><td style="text-align:left">url</br><code>string</code></td><td style="text-align:left"><p>The endpoint where this list of publications can be accessed using a GET method. <code>/v1/vouchers/{voucher_code}/publications</code></p> <strong>Example:</strong> <p>/v1/vouchers/WVPblOYX/publications?page=1&amp;limit=10</p></td></tr></tbody></table> |
 | redemption</br>`object` | <p>Stores a summary of redemptions that have been applied to the voucher.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">quantity</br><code>integer</code></td><td style="text-align:left"><p>How many times a voucher can be redeemed. A <code>null</code> value means unlimited.</p></td></tr><tr><td style="text-align:left">redeemed_quantity</br><code>integer</code></td><td style="text-align:left"><p>How many times a voucher has already been redeemed.</p> <strong>Example:</strong> <p>1</p></td></tr><tr><td style="text-align:left">redeemed_points</br><code>integer</code></td><td style="text-align:left"><p>Total loyalty points redeemed.</p> <strong>Example:</strong> <p>100000</p></td></tr><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>The type of the object represented is by default <code>list</code>. To get this list, you need to make a call to the endpoint returned in the url attribute.</p></td></tr><tr><td style="text-align:left">url</br><code>string</code></td><td style="text-align:left"><p>The endpoint where this list of redemptions can be accessed using a GET method. <code>/v1/vouchers/{voucher_code}/redemptions</code></p> <strong>Example:</strong> <p>/v1/vouchers/WVPblOYX/redemptions?page=1&amp;limit=10</p></td></tr></tbody></table> |
+
+## Category
+| Attributes |  Description |
+|:-----|:--------|
+| id</br>`string` | <p>Unique category ID assigned by Voucherify.</p> |
+| name</br>`string` | <p>Category name.</p> |
+| hierarchy</br>`integer` | <p>Category hierarchy.</p> |
+| object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
+| created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
+| updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
 
 ## Validation Rules Assignments List
 | Attributes |  Description |

--- a/docs/reference-docs/REDEMPTIONS-Rollback-Redemption-Object.md
+++ b/docs/reference-docs/REDEMPTIONS-Rollback-Redemption-Object.md
@@ -210,7 +210,6 @@ All of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Validation Rules Assignments List
 | Attributes |  Description |

--- a/docs/reference-docs/VOUCHERS-Voucher-Object.md
+++ b/docs/reference-docs/VOUCHERS-Voucher-Object.md
@@ -56,7 +56,6 @@ All of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-| stacking_rules_type</br>`string` | <p>The type of the stacking rule eligibility.</p> Available values: `JOINT`, `EXCLUSIVE` |
 
 ## Validation Rules Assignments List
 | Attributes |  Description |

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -3168,18 +3168,33 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
-          },
-          "stacking_rules_type": {
-            "type": "string",
-            "description": "The type of the stacking rule eligibility.",
-            "enum": [
-              "JOINT",
-              "EXCLUSIVE"
-            ],
-            "nullable": true
           }
         },
         "required": []
+      },
+      "CategoryStackingRulesType": {
+        "type": "object",
+        "title": "Category with Stacking Rules Type",
+        "description": "Category object with `stacking_rules_type`",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Category"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "stacking_rules_type": {
+                "type": "string",
+                "description": "The type of the stacking rule eligibility.",
+                "enum": [
+                  "JOINT",
+                  "EXCLUSIVE"
+                ],
+                "nullable": true
+              }
+            }
+          }
+        ]
       },
       "ClientEventsCreateRequestBody": {
         "description": "Request body schema for **POST** `v1/events`.",
@@ -19786,7 +19801,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },
@@ -25641,7 +25656,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -25712,7 +25727,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -25783,7 +25798,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -25947,7 +25962,7 @@
       },
       "ValidationsValidateResponseBody": {
         "title": "Validations Validate Response Body",
-        "description": "Response body schema for POST `/validations`.",
+        "description": "Response body schema for **POST** `v1/validations`.",
         "type": "object",
         "properties": {
           "valid": {

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -3172,7 +3172,7 @@
         },
         "required": []
       },
-      "CategoryStackingRulesType": {
+      "CategoryWithStackingRulesType": {
         "type": "object",
         "title": "Category with Stacking Rules Type",
         "description": "Category object with `stacking_rules_type`",
@@ -19801,7 +19801,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },
@@ -25656,7 +25656,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -25727,7 +25727,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -25798,7 +25798,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -4187,7 +4187,7 @@
                 "type": "array",
                 "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                  "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                 }
               },
               "validation_rules_assignments": {
@@ -15535,7 +15535,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             }
           }
         },
@@ -15600,7 +15600,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             }
           }
         },
@@ -15670,7 +15670,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             }
           }
         },
@@ -33072,7 +33072,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             }
           },
           "banner": {
@@ -36811,7 +36811,7 @@
           "object"
         ]
       },
-      "CategoryStackingRulesType": {
+      "CategoryWithStackingRulesType": {
         "type": "object",
         "title": "Category with Stacking Rules Type",
         "description": "Category object with `stacking_rules_type`",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -4172,6 +4172,31 @@
           }
         ]
       },
+      "VoucherQualificationValidationRedemption": {
+        "title": "Voucher",
+        "readmeTitle": "Voucher with categories and validation rules assignments",
+        "description": "This is an object representing a voucher with categories and validation rules assignments for **POST** `v1/qualifications`, **POST** `v1/redemptions`, and **POST** `v1/validations`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoucherBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "categories": {
+                "type": "array",
+                "description": "Contains details about the category.",
+                "items": {
+                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                }
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              }
+            }
+          }
+        ]
+      },
       "VoucherBase": {
         "title": "Voucher Base",
         "description": "This is an object representing a voucher.",
@@ -15382,7 +15407,7 @@
       },
       "ValidationsValidateResponseBody": {
         "title": "Validations Validate Response Body",
-        "description": "Response body schema for POST `/validations`.",
+        "description": "Response body schema for **POST** `v1/validations`.",
         "type": "object",
         "properties": {
           "valid": {
@@ -15510,7 +15535,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             }
           }
         },
@@ -15575,7 +15600,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             }
           }
         },
@@ -15645,7 +15670,7 @@
           "categories": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             }
           }
         },
@@ -33047,7 +33072,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             }
           },
           "banner": {
@@ -36776,14 +36801,6 @@
             "example": "2022-08-16T10:52:08.094Z",
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time"
-          },
-          "stacking_rules_type": {
-            "type": "string",
-            "description": "The type of the stacking rule eligibility.",
-            "enum": [
-              "JOINT",
-              "EXCLUSIVE"
-            ]
           }
         },
         "required": [
@@ -36792,6 +36809,29 @@
           "hierarchy",
           "created_at",
           "object"
+        ]
+      },
+      "CategoryStackingRulesType": {
+        "type": "object",
+        "title": "Category with Stacking Rules Type",
+        "description": "Category object with `stacking_rules_type`",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Category"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "stacking_rules_type": {
+                "type": "string",
+                "description": "The type of the stacking rule eligibility.",
+                "enum": [
+                  "JOINT",
+                  "EXCLUSIVE"
+                ]
+              }
+            }
+          }
         ]
       },
       "CategoriesListResponseBody": {

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -2945,7 +2945,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -26288,7 +26288,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -29425,8 +29425,8 @@
         },
         "required": []
       },
-      "CategoryStackingRulesType": {
-        "title": "CategoryStackingRulesType",
+      "CategoryWithStackingRulesType": {
+        "title": "CategoryWithStackingRulesType",
         "type": "object",
         "properties": {
           "id": {
@@ -38279,7 +38279,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -38354,7 +38354,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -40243,7 +40243,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },
@@ -40877,7 +40877,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -2167,15 +2167,6 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
-          },
-          "stacking_rules_type": {
-            "type": "string",
-            "description": "The type of the stacking rule eligibility.",
-            "enum": [
-              "JOINT",
-              "EXCLUSIVE"
-            ],
-            "nullable": true
           }
         },
         "required": [],
@@ -2954,7 +2945,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -26082,7 +26073,7 @@
       },
       "ValidationsValidateResponseBody": {
         "title": "ValidationsValidateResponseBody",
-        "description": "Response body schema for POST `/validations`.",
+        "description": "Response body schema for **POST** `v1/validations`.",
         "type": "object",
         "properties": {
           "valid": {
@@ -26297,7 +26288,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -29430,6 +29421,51 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
+          }
+        },
+        "required": []
+      },
+      "CategoryStackingRulesType": {
+        "title": "CategoryStackingRulesType",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique category ID assigned by Voucherify.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Category name.",
+            "nullable": true
+          },
+          "hierarchy": {
+            "type": "integer",
+            "description": "Category hierarchy.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "default": "category",
+            "enum": [
+              "category"
+            ],
+            "description": "The type of the object represented by the JSON. This object stores information about the category.",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.",
+            "example": "2022-07-14T10:45:13.156Z",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2022-08-16T10:52:08.094Z",
+            "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
           },
           "stacking_rules_type": {
             "type": "string",
@@ -29441,7 +29477,7 @@
             "nullable": true
           }
         },
-        "required": []
+        "description": "Category object with `stacking_rules_type`"
       },
       "CodeConfig": {
         "title": "CodeConfig",
@@ -38243,7 +38279,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -38318,7 +38354,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -40207,7 +40243,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },
@@ -40841,7 +40877,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -2279,15 +2279,6 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
-          },
-          "stacking_rules_type": {
-            "type": "string",
-            "description": "The type of the stacking rule eligibility.",
-            "enum": [
-              "JOINT",
-              "EXCLUSIVE"
-            ],
-            "nullable": true
           }
         },
         "required": [],
@@ -3066,7 +3057,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -26971,7 +26962,7 @@
       },
       "ValidationsValidateResponseBody": {
         "title": "ValidationsValidateResponseBody",
-        "description": "Response body schema for POST `/validations`.",
+        "description": "Response body schema for **POST** `v1/validations`.",
         "type": "object",
         "properties": {
           "valid": {
@@ -27186,7 +27177,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -30501,6 +30492,51 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
+          }
+        },
+        "required": []
+      },
+      "CategoryStackingRulesType": {
+        "title": "CategoryStackingRulesType",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique category ID assigned by Voucherify.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Category name.",
+            "nullable": true
+          },
+          "hierarchy": {
+            "type": "integer",
+            "description": "Category hierarchy.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "default": "category",
+            "enum": [
+              "category"
+            ],
+            "description": "The type of the object represented by the JSON. This object stores information about the category.",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.",
+            "example": "2022-07-14T10:45:13.156Z",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2022-08-16T10:52:08.094Z",
+            "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
           },
           "stacking_rules_type": {
             "type": "string",
@@ -30512,7 +30548,7 @@
             "nullable": true
           }
         },
-        "required": []
+        "description": "Category object with `stacking_rules_type`"
       },
       "CodeConfig": {
         "title": "CodeConfig",
@@ -39511,7 +39547,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -39586,7 +39622,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -41507,7 +41543,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },
@@ -42147,7 +42183,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -3057,7 +3057,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -27177,7 +27177,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -30496,8 +30496,8 @@
         },
         "required": []
       },
-      "CategoryStackingRulesType": {
-        "title": "CategoryStackingRulesType",
+      "CategoryWithStackingRulesType": {
+        "title": "CategoryWithStackingRulesType",
         "type": "object",
         "properties": {
           "id": {
@@ -39547,7 +39547,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -39622,7 +39622,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -41543,7 +41543,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },
@@ -42183,7 +42183,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -2945,7 +2945,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -26094,7 +26094,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -29231,8 +29231,8 @@
         },
         "required": []
       },
-      "CategoryStackingRulesType": {
-        "title": "CategoryStackingRulesType",
+      "CategoryWithStackingRulesType": {
+        "title": "CategoryWithStackingRulesType",
         "type": "object",
         "properties": {
           "id": {
@@ -37733,7 +37733,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -37808,7 +37808,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -39697,7 +39697,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },
@@ -40331,7 +40331,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -2167,15 +2167,6 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
-          },
-          "stacking_rules_type": {
-            "type": "string",
-            "description": "The type of the stacking rule eligibility.",
-            "enum": [
-              "JOINT",
-              "EXCLUSIVE"
-            ],
-            "nullable": true
           }
         },
         "required": [],
@@ -2954,7 +2945,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -25888,7 +25879,7 @@
       },
       "ValidationsValidateResponseBody": {
         "title": "ValidationsValidateResponseBody",
-        "description": "Response body schema for POST `/validations`.",
+        "description": "Response body schema for **POST** `v1/validations`.",
         "type": "object",
         "properties": {
           "valid": {
@@ -26103,7 +26094,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -29236,6 +29227,51 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
+          }
+        },
+        "required": []
+      },
+      "CategoryStackingRulesType": {
+        "title": "CategoryStackingRulesType",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique category ID assigned by Voucherify.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Category name.",
+            "nullable": true
+          },
+          "hierarchy": {
+            "type": "integer",
+            "description": "Category hierarchy.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "default": "category",
+            "enum": [
+              "category"
+            ],
+            "description": "The type of the object represented by the JSON. This object stores information about the category.",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.",
+            "example": "2022-07-14T10:45:13.156Z",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2022-08-16T10:52:08.094Z",
+            "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
           },
           "stacking_rules_type": {
             "type": "string",
@@ -29247,7 +29283,7 @@
             "nullable": true
           }
         },
-        "required": []
+        "description": "Category object with `stacking_rules_type`"
       },
       "CodeConfig": {
         "title": "CodeConfig",
@@ -37697,7 +37733,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -37772,7 +37808,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -39661,7 +39697,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },
@@ -40295,7 +40331,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -2945,7 +2945,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -26322,7 +26322,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CategoryStackingRulesType"
+                    "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -29459,8 +29459,8 @@
         },
         "required": []
       },
-      "CategoryStackingRulesType": {
-        "title": "CategoryStackingRulesType",
+      "CategoryWithStackingRulesType": {
+        "title": "CategoryWithStackingRulesType",
         "type": "object",
         "properties": {
           "id": {
@@ -38313,7 +38313,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -38388,7 +38388,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           }
@@ -40277,7 +40277,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },
@@ -40911,7 +40911,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/CategoryStackingRulesType"
+              "$ref": "#/components/schemas/CategoryWithStackingRulesType"
             },
             "nullable": true
           },

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -2167,15 +2167,6 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
-          },
-          "stacking_rules_type": {
-            "type": "string",
-            "description": "The type of the stacking rule eligibility.",
-            "enum": [
-              "JOINT",
-              "EXCLUSIVE"
-            ],
-            "nullable": true
           }
         },
         "required": [],
@@ -2954,7 +2945,7 @@
                   "title": "ClientValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -26116,7 +26107,7 @@
       },
       "ValidationsValidateResponseBody": {
         "title": "ValidationsValidateResponseBody",
-        "description": "Response body schema for POST `/validations`.",
+        "description": "Response body schema for **POST** `v1/validations`.",
         "type": "object",
         "properties": {
           "valid": {
@@ -26331,7 +26322,7 @@
                   "title": "ValidationsValidateResponseBodyRedeemablesItemCategories",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category"
+                    "$ref": "#/components/schemas/CategoryStackingRulesType"
                   },
                   "nullable": true
                 }
@@ -29464,6 +29455,51 @@
             "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
             "format": "date-time",
             "nullable": true
+          }
+        },
+        "required": []
+      },
+      "CategoryStackingRulesType": {
+        "title": "CategoryStackingRulesType",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique category ID assigned by Voucherify.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Category name.",
+            "nullable": true
+          },
+          "hierarchy": {
+            "type": "integer",
+            "description": "Category hierarchy.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "default": "category",
+            "enum": [
+              "category"
+            ],
+            "description": "The type of the object represented by the JSON. This object stores information about the category.",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.",
+            "example": "2022-07-14T10:45:13.156Z",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2022-08-16T10:52:08.094Z",
+            "description": "Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
           },
           "stacking_rules_type": {
             "type": "string",
@@ -29475,7 +29511,7 @@
             "nullable": true
           }
         },
-        "required": []
+        "description": "Category object with `stacking_rules_type`"
       },
       "CodeConfig": {
         "title": "CodeConfig",
@@ -38277,7 +38313,7 @@
             "title": "ValidationsRedeemableInapplicableCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -38352,7 +38388,7 @@
             "title": "ValidationsRedeemableSkippedCategories",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           }
@@ -40241,7 +40277,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },
@@ -40875,7 +40911,7 @@
             "type": "array",
             "description": "List of category information.",
             "items": {
-              "$ref": "#/components/schemas/Category"
+              "$ref": "#/components/schemas/CategoryStackingRulesType"
             },
             "nullable": true
           },


### PR DESCRIPTION
## Why

The `stacking_rules_type` property in the `categories` array should be displayed ONLY for:
- **POST** `v1/qualifications`
- **POST** `v1/redemptions`
- **POST** `v1/validations`

## How

This PR contains only changes for `qualifications` and `validations`.

`redemptions` is more complicated – possible solution in https://github.com/voucherifyio/voucherify-openapi/pull/819

