### PR TITLE
PW – Categories in Redemptions

### DIFF
--- a/docs/reference-docs/REDEMPTIONS-Redemption-Object.md
+++ b/docs/reference-docs/REDEMPTIONS-Redemption-Object.md
@@ -11,39 +11,19 @@ order: 1
 ## Redemptions Redeem Response Body
 | Attributes |  Description |
 |:-----|:--------|
-| redemptions</br>`array` | Array of [Redemption](#redemption) |
-| parent_redemption | See: [Redemption](#redemption) |
+| redemptions</br>`array` | Array of [Redemption Redeem](#redemption-redeem) |
+| parent_redemption | See: [Redemption Redeem](#redemption-redeem) |
 | order | <p>Contains the order details associated with the redemption.</p> [Order Calculated No Customer Data](#order-calculated-no-customer-data) |
 | inapplicable_redeemables</br>`array` | <p>Lists validation results of each inapplicable redeemable.</p> Array of [Inapplicable Redeemable](#inapplicable-redeemable) |
 | skipped_redeemables</br>`array` | <p>Lists validation results of each redeemable. If a redeemable can be applied, the API returns <code>&quot;status&quot;: &quot;APPLICABLE&quot;</code>.</p> Array of [Skipped Redeemable](#skipped-redeemable) |
 
-## Redemption
-| Attributes |  Description |
-|:-----|:--------|
-| id</br>`string` | <p>Unique redemption ID.</p> **Example:** <p>r_0bc92f81a6801f9bca</p> |
-| object</br>`string` | <p>The type of the object represented by the JSON</p> Available values: `redemption` |
-| date</br>`string` | <p>Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-22T10:13:06.487Z</p> |
-| customer_id</br>`string`, `null` | <p>Unique customer ID of the redeeming customer.</p> **Example:** <p>cust_i8t5Tt6eiKG5K79KQlJ0Vs64</p> |
-| tracking_id</br>`string`, `null` | <p>Hashed customer source ID.</p> |
-| metadata</br>`object`, `null` | <p>The metadata object stores all custom attributes assigned to the redemption.</p> |
-| amount</br>`integer` | <p>For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.<br>For loyalty cards, this is the number of loyalty points used in the transaction.</p> **Example:** <p>10000</p> |
-| redemption</br>`string`, `null` | <p>Unique redemption ID of the parent redemption.</p> **Example:** <p>r_0c656311b5878a2031</p> |
-| result</br>`string` | <p>Redemption result.</p> Available values: `SUCCESS`, `FAILURE` |
-| status</br>`string` | <p>Redemption status.</p> Available values: `SUCCEEDED`, `FAILED`, `ROLLED_BACK` |
-| related_redemptions</br>`object` | <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">rollbacks</br><code>array</code></td><td style="text-align:left">Array of: <h4>Redemption Related Redemptions Rollbacks Item</h4><table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique rollback redemption ID.</p> <strong>Example:</strong> <p>rr_0bc92f81a6801f9bca</p></td></tr><tr><td style="text-align:left">date</br><code>string</code></td><td style="text-align:left"><p>Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.</p> <strong>Example:</strong> <p>2021-12-22T10:13:06.487Z</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">redemptions</br><code>array</code></td><td style="text-align:left">Array of: <h4>Redemption Related Redemptions Item</h4><table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique redemption ID.</p> <strong>Example:</strong> <p>r_0bc92f81a6801f9bca</p></td></tr><tr><td style="text-align:left">date</br><code>string</code></td><td style="text-align:left"><p>Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.</p> <strong>Example:</strong> <p>2021-12-22T10:13:06.487Z</p></td></tr></tbody></table></td></tr></tbody></table> |
-| failure_code</br>`string` | <p>If the result is <code>FAILURE</code>, this parameter will provide a generic reason as to why the redemption failed.</p> **Example:** <p>customer_rules_violated</p> |
-| failure_message</br>`string` | <p>If the result is <code>FAILURE</code>, this parameter will provide a more expanded reason as to why the redemption failed.</p> |
-| order | [Order Calculated No Customer Data](#order-calculated-no-customer-data) |
-| channel</br>`object` | <p>Defines the details of the channel through which the redemption was issued.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">channel_id</br><code>string</code></td><td style="text-align:left"><p>Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.</p> <strong>Example:</strong> <p>user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH</p></td></tr><tr><td style="text-align:left">channel_type</br><code>string</code></td><td style="text-align:left"><p>The source of the channel for the redemption. A <code>USER</code> corresponds to the Voucherify Dashboard and an <code>API</code> corresponds to the API.</p> Available values: <code>USER</code>, <code>API</code></td></tr></tbody></table> |
-| customer | [Simple Customer](#simple-customer) |
-| related_object_type</br>`string` | <p>Defines the related object.</p> Available values: `voucher`, `promotion_tier`, `redemption` |
-| related_object_id</br>`string` | <p>Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.</p> |
-| voucher | <p>Defines the details of the voucher being redeemed.</p> All of: 1. [Voucher](#voucher)
-2. [Voucher Holder](#voucher-holder) |
-| promotion_tier | <p>Contains details of the promotion tier and the parent campaign.</p> [Promotion Tier](#promotion-tier) |
-| reward | See: [Redemption Reward Result](#redemption-reward-result) |
-| gift</br>`object` | <p>Contains the amount subtracted from the gift card for the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">amount</br><code>integer</code></td><td style="text-align:left"><p>Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).</p></td></tr></tbody></table> |
-| loyalty_card</br>`object` | <p>Contains the number of points subtracted from the loyalty card for the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Number of points subtracted from the loyalty card as a result of the redemption.</p></td></tr></tbody></table> |
+## Redemption Redeem
+<p>This is an object representing a redemption for <strong>POST</strong> <code>v1/redemptions</code>, <strong>POST</strong> <code>v1/loyalties/{campaignId}/members/{memberId}/redemption</code>, <strong>POST</strong> <code>v1/loyalties/members/{memberId}/redemption</code>, <strong>POST</strong> <code>/client/v1/redemptions</code>.</p>
+
+All of:
+
+1. [Redemption Base](#redemption-base)
+2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">voucher</td><td style="text-align:left"><p>Defines the details of the voucher being redeemed.</p> All of: 1. <a href="#voucher">Voucher</a></td></tr></tbody></table><ol start="2"><li><a href="#voucher-holder">Voucher Holder</a> |</li></ol>
 
 ## Order Calculated No Customer Data
 | Attributes |  Description |
@@ -91,72 +71,44 @@ order: 1
 | metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
 | categories</br>`array` | Array of [Category with Stacking Rules Type](#category-with-stacking-rules-type) |
 
-## Simple Customer
+## Redemption Base
 | Attributes |  Description |
 |:-----|:--------|
-| id</br>`string` | <p>Unique identifier of an existing customer. It is assigned by Voucherify.</p> |
-| name</br>`string` | <p>Customer's first and last name.</p> |
-| email</br>`string` | <p>Customer's email address.</p> |
-| source_id</br>`string` | <p>A unique identifier of the customer. It can be a customer ID or email from a CRM system, database, or a third-party service.</p> |
-| metadata</br>`object` | <p>A set of custom key/value pairs that are attached to the customer. It stores all custom attributes assigned to the customer.</p> |
-| object</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `customer` |
+| id</br>`string` | <p>Unique redemption ID.</p> **Example:** <p>r_0bc92f81a6801f9bca</p> |
+| object</br>`string` | <p>The type of the object represented by the JSON</p> Available values: `redemption` |
+| date</br>`string` | <p>Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-22T10:13:06.487Z</p> |
+| customer_id</br>`string`, `null` | <p>Unique customer ID of the redeeming customer.</p> **Example:** <p>cust_i8t5Tt6eiKG5K79KQlJ0Vs64</p> |
+| tracking_id</br>`string`, `null` | <p>Hashed customer source ID.</p> |
+| metadata</br>`object`, `null` | <p>The metadata object stores all custom attributes assigned to the redemption.</p> |
+| amount</br>`integer` | <p>For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.<br>For loyalty cards, this is the number of loyalty points used in the transaction.</p> **Example:** <p>10000</p> |
+| redemption</br>`string`, `null` | <p>Unique redemption ID of the parent redemption.</p> **Example:** <p>r_0c656311b5878a2031</p> |
+| result</br>`string` | <p>Redemption result.</p> Available values: `SUCCESS`, `FAILURE` |
+| status</br>`string` | <p>Redemption status.</p> Available values: `SUCCEEDED`, `FAILED`, `ROLLED_BACK` |
+| related_redemptions</br>`object` | <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">rollbacks</br><code>array</code></td><td style="text-align:left">Array of: <h4>Redemption Related Redemptions Rollbacks Item</h4><table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique rollback redemption ID.</p> <strong>Example:</strong> <p>rr_0bc92f81a6801f9bca</p></td></tr><tr><td style="text-align:left">date</br><code>string</code></td><td style="text-align:left"><p>Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.</p> <strong>Example:</strong> <p>2021-12-22T10:13:06.487Z</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">redemptions</br><code>array</code></td><td style="text-align:left">Array of: <h4>Redemption Related Redemptions Item</h4><table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique redemption ID.</p> <strong>Example:</strong> <p>r_0bc92f81a6801f9bca</p></td></tr><tr><td style="text-align:left">date</br><code>string</code></td><td style="text-align:left"><p>Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.</p> <strong>Example:</strong> <p>2021-12-22T10:13:06.487Z</p></td></tr></tbody></table></td></tr></tbody></table> |
+| failure_code</br>`string` | <p>If the result is <code>FAILURE</code>, this parameter will provide a generic reason as to why the redemption failed.</p> **Example:** <p>customer_rules_violated</p> |
+| failure_message</br>`string` | <p>If the result is <code>FAILURE</code>, this parameter will provide a more expanded reason as to why the redemption failed.</p> |
+| order | [Order Calculated No Customer Data](#order-calculated-no-customer-data) |
+| channel</br>`object` | <p>Defines the details of the channel through which the redemption was issued.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">channel_id</br><code>string</code></td><td style="text-align:left"><p>Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.</p> <strong>Example:</strong> <p>user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH</p></td></tr><tr><td style="text-align:left">channel_type</br><code>string</code></td><td style="text-align:left"><p>The source of the channel for the redemption. A <code>USER</code> corresponds to the Voucherify Dashboard and an <code>API</code> corresponds to the API.</p> Available values: <code>USER</code>, <code>API</code></td></tr></tbody></table> |
+| customer | [Simple Customer](#simple-customer) |
+| related_object_type</br>`string` | <p>Defines the related object.</p> Available values: `voucher`, `promotion_tier`, `redemption` |
+| related_object_id</br>`string` | <p>Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.</p> |
+| promotion_tier | <p>Contains details of the promotion tier and the parent campaign.</p> [Promotion Tier](#promotion-tier) |
+| reward | See: [Redemption Reward Result](#redemption-reward-result) |
+| gift</br>`object` | <p>Contains the amount subtracted from the gift card for the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">amount</br><code>integer</code></td><td style="text-align:left"><p>Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).</p></td></tr></tbody></table> |
+| loyalty_card</br>`object` | <p>Contains the number of points subtracted from the loyalty card for the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Number of points subtracted from the loyalty card as a result of the redemption.</p></td></tr></tbody></table> |
 
 ## Voucher
-<p>This is an object representing a voucher with categories and validation rules assignments.</p>
+<p>This is an object representing a voucher with categories and validation rules assignments for <strong>POST</strong> <code>v1/qualifications</code>, <strong>POST</strong> <code>v1/redemptions</code>, and <strong>POST</strong> <code>v1/validations</code>.</p>
 
 All of:
 
 1. [Voucher Base](#voucher-base)
-2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">categories</br><code>array</code></td><td style="text-align:left"><p>Contains details about the category.</p> Array of <a href="#category">Category</a></td></tr><tr><td style="text-align:left">validation_rules_assignments</td><td style="text-align:left">See: <a href="#validation-rules-assignments-list">Validation Rules Assignments List</a></td></tr></tbody></table>
+2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">categories</br><code>array</code></td><td style="text-align:left"><p>Contains details about the category.</p> Array of <a href="#category-with-stacking-rules-type">Category with Stacking Rules Type</a></td></tr><tr><td style="text-align:left">validation_rules_assignments</td><td style="text-align:left">See: <a href="#validation-rules-assignments-list">Validation Rules Assignments List</a></td></tr></tbody></table>
 
 ## Voucher Holder
 | Attributes |  Description |
 |:-----|:--------|
 | holder | See: [Simple Customer](#simple-customer) |
-
-## Promotion Tier
-| Attributes |  Description |
-|:-----|:--------|
-| id</br>`string` | <p>Unique promotion tier ID.</p> **Example:** <p>promo_63fYCt81Aw0h7lzyRkrGZh9p</p> |
-| created_at</br>`string` | <p>Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-15T11:34:01.333Z</p> |
-| updated_at</br>`string` | <p>Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-02-09T09:20:05.603Z</p> |
-| name</br>`string` | <p>Name of the promotion tier.</p> |
-| banner</br>`string` | <p>Text to be displayed to your customers on your website.</p> |
-| action</br>`object` | <p>Contains details about the discount applied by the promotion tier.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">discount</td><td style="text-align:left">See: <a href="#discount">Discount</a></td></tr></tbody></table> |
-| metadata</br>`object` | <p>The metadata object stores all custom attributes assigned to the promotion tier. A set of key/value pairs that you can attach to a promotion tier object. It can be useful for storing additional information about the promotion tier in a structured format.</p> |
-| hierarchy</br>`integer` | <p>The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.</p> |
-| promotion_id</br>`string` | <p>Promotion unique ID.</p> |
-| campaign</br>`object` | <p>Contains details about promotion tier's parent campaign.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique campaign ID.</p></td></tr><tr><td style="text-align:left">start_date</br><code>string</code></td><td style="text-align:left"><p>Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is <em>inactive before</em> this date.</p> <strong>Example:</strong> <p>2022-09-22T00:00:00.000Z</p></td></tr><tr><td style="text-align:left">expiration_date</br><code>string</code></td><td style="text-align:left"><p>Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is <em>inactive after</em> this date.</p> <strong>Example:</strong> <p>2022-09-30T00:00:00.000Z</p></td></tr><tr><td style="text-align:left">validity_timeframe</td><td style="text-align:left">See: <a href="#validity-timeframe">Validity Timeframe</a></td></tr><tr><td style="text-align:left">validity_day_of_week</td><td style="text-align:left">See: <a href="#validity-day-of-week">Validity Day Of Week</a></td></tr><tr><td style="text-align:left">validity_hours</td><td style="text-align:left">See: <a href="#validity-hours">Validity Hours</a></td></tr><tr><td style="text-align:left">active</br><code>boolean</code></td><td style="text-align:left"><p>A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the <code>start_date</code> and <code>expiration_date</code> using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) --><a href="ref:disable-campaign">Disable Campaign</a> endpoint.</p><ul><li><code>true</code> indicates an <em>active</em> campaign</li><li><code>false</code> indicates an <em>inactive</em> campaign</li></ul></td></tr><tr><td style="text-align:left">category_id</br><code>string</code></td><td style="text-align:left"><p>Unique category ID that this campaign belongs to.</p> <strong>Example:</strong> <p>cat_0b688929a2476386a6</p></td></tr><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>The type of the object represented by the campaign object. This object stores information about the campaign.</p></td></tr></tbody></table> |
-| campaign_id</br>`string` | <p>Promotion tier's parent campaign's unique ID.</p> |
-| active</br>`boolean` | <p>A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the <code>start_date</code> and <code>expiration_date</code>.</p><ul><li><code>true</code> indicates an <em>active</em> promotion tier</li><li><code>false</code> indicates an <em>inactive</em> promotion tier</li></ul> |
-| start_date</br>`string` | <p>Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is <em>inactive before</em> this date.</p> **Example:** <p>2022-09-23T00:00:00.000Z</p> |
-| expiration_date</br>`string` | <p>Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is <em>inactive after</em> this date.</p> **Example:** <p>2022-09-26T00:00:00.000Z</p> |
-| validity_timeframe | See: [Validity Timeframe](#validity-timeframe) |
-| validity_day_of_week | See: [Validity Day Of Week](#validity-day-of-week) |
-| validity_hours | See: [Validity Hours](#validity-hours) |
-| summary</br>`object` | <p>Contains statistics about promotion tier redemptions and orders.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">redemptions</br><code>object</code></td><td style="text-align:left"><p>Contains statistics about promotion tier redemptions.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">total_redeemed</br><code>integer</code></td><td style="text-align:left"><p>Number of times the promotion tier was redeemed.</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">orders</br><code>object</code></td><td style="text-align:left"><p>Contains statistics about orders related to the promotion tier.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">total_amount</br><code>integer</code></td><td style="text-align:left"><p>Sum of order totals.</p></td></tr><tr><td style="text-align:left">total_discount_amount</br><code>integer</code></td><td style="text-align:left"><p>Sum of total discount applied using the promotion tier.</p></td></tr></tbody></table></td></tr></tbody></table> |
-| object</br>`string` | <p>The type of the object represented by JSON. This object stores information about the promotion tier.</p> |
-| validation_rule_assignments | See: [Validation Rule Assignments List](#validation-rule-assignments-list) |
-| category_id</br>`string` | <p>Promotion tier category ID.</p> **Example:** <p>cat_0c9da30e7116ba6bba</p> |
-| categories</br>`array` | Array of [Category](#category) |
-
-## Redemption Reward Result
-| Attributes |  Description |
-|:-----|:--------|
-| customer | [Simple Customer](#simple-customer) |
-| assignment_id</br>`string`, `null` | <p>Unique reward assignment ID assigned by Voucherify.</p> |
-| voucher | [Voucher](#voucher) |
-| product | [Product](#product) |
-| sku | [SKU Object](#sku-object) |
-| loyalty_tier_id</br>`string`, `null` | <p>Unique loyalty tier ID assigned by Voucherify.</p> |
-| id</br>`string` | <p>Unique reward ID.</p> **Example:** <p>rew_0bc92f81a6801f9bca</p> |
-| name</br>`string` | <p>Name of the reward.</p> **Example:** <p>Reward Name</p> |
-| object</br>`string` | <p>The type of the object represented by the JSON</p> Available values: `reward` |
-| created_at</br>`string` | <p>Timestamp representing the date and time when the redemption was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-22T10:13:06.487Z</p> |
-| updated_at</br>`string` | <p>Timestamp in ISO 8601 format indicating when the reward was updated.</p> **Example:** <p>2022-10-03T12:24:58.008Z</p> |
-| parameters</br>`object` | <p>These are parameters representing a material reward.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">campaign</br><code>object</code></td><td style="text-align:left"><p>Defines the product redeemed as a reward.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Campaign unique ID.</p> <strong>Example:</strong> <p>camp_13BbZ0kQsNinhqsX3wUts2UP</p></td></tr><tr><td style="text-align:left">balance</br><code>integer</code></td><td style="text-align:left"><p>Points available for reward redemption.</p></td></tr><tr><td style="text-align:left">type</br><code>string</code></td><td style="text-align:left"><p>Defines the type of the campaign.</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">product</br><code>object</code></td><td style="text-align:left"><p>Defines the product redeemed as a reward.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique product ID, assigned by Voucherify.</p> <strong>Example:</strong> <p>prod_0b7d7dfb05cbe5c616</p></td></tr><tr><td style="text-align:left">sku_id</br><code>string</code></td><td style="text-align:left"><p>Unique identifier of the SKU. It is assigned by Voucherify.</p> <strong>Example:</strong> <p>sku_0a41e31c7b41c28358</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">coin</br><code>object</code></td><td style="text-align:left"><p>Defines the ratio by mapping the number of loyalty points in <code>points_ratio</code> to a predefined cash amount in <code>exchange_ratio</code>.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">exchange_ratio</br><code>integer</code></td><td style="text-align:left"><p>The cash equivalent of the points defined in the <code>points_ratio</code> property.</p></td></tr><tr><td style="text-align:left">points_ratio</br><code>integer</code></td><td style="text-align:left"><p>The number of loyalty points that will map to the predefined cash amount defined by the <code>exchange_ratio</code> property.</p></td></tr></tbody></table></td></tr></tbody></table> |
-| metadata</br>`object` | <p>A set of custom key/value pairs that you can attach to a reward. The metadata object stores all custom attributes assigned to the reward.</p> |
-| type</br>`string` | <p>Reward type.</p> Available values: `CAMPAIGN`, `COIN`, `MATERIAL` |
 
 ## Order Item Calculated
 | Attributes |  Description |
@@ -259,6 +211,60 @@ All of:
 | key</br>`string` | Available values: `preceding_validation_failed` |
 | message</br>`string` | **Example:** <p>Redeemable cannot be applied due to preceding validation failure</p> |
 
+## Simple Customer
+| Attributes |  Description |
+|:-----|:--------|
+| id</br>`string` | <p>Unique identifier of an existing customer. It is assigned by Voucherify.</p> |
+| name</br>`string` | <p>Customer's first and last name.</p> |
+| email</br>`string` | <p>Customer's email address.</p> |
+| source_id</br>`string` | <p>A unique identifier of the customer. It can be a customer ID or email from a CRM system, database, or a third-party service.</p> |
+| metadata</br>`object` | <p>A set of custom key/value pairs that are attached to the customer. It stores all custom attributes assigned to the customer.</p> |
+| object</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `customer` |
+
+## Promotion Tier
+| Attributes |  Description |
+|:-----|:--------|
+| id</br>`string` | <p>Unique promotion tier ID.</p> **Example:** <p>promo_63fYCt81Aw0h7lzyRkrGZh9p</p> |
+| created_at</br>`string` | <p>Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-15T11:34:01.333Z</p> |
+| updated_at</br>`string` | <p>Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-02-09T09:20:05.603Z</p> |
+| name</br>`string` | <p>Name of the promotion tier.</p> |
+| banner</br>`string` | <p>Text to be displayed to your customers on your website.</p> |
+| action</br>`object` | <p>Contains details about the discount applied by the promotion tier.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">discount</td><td style="text-align:left">See: <a href="#discount">Discount</a></td></tr></tbody></table> |
+| metadata</br>`object` | <p>The metadata object stores all custom attributes assigned to the promotion tier. A set of key/value pairs that you can attach to a promotion tier object. It can be useful for storing additional information about the promotion tier in a structured format.</p> |
+| hierarchy</br>`integer` | <p>The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.</p> |
+| promotion_id</br>`string` | <p>Promotion unique ID.</p> |
+| campaign</br>`object` | <p>Contains details about promotion tier's parent campaign.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique campaign ID.</p></td></tr><tr><td style="text-align:left">start_date</br><code>string</code></td><td style="text-align:left"><p>Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is <em>inactive before</em> this date.</p> <strong>Example:</strong> <p>2022-09-22T00:00:00.000Z</p></td></tr><tr><td style="text-align:left">expiration_date</br><code>string</code></td><td style="text-align:left"><p>Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is <em>inactive after</em> this date.</p> <strong>Example:</strong> <p>2022-09-30T00:00:00.000Z</p></td></tr><tr><td style="text-align:left">validity_timeframe</td><td style="text-align:left">See: <a href="#validity-timeframe">Validity Timeframe</a></td></tr><tr><td style="text-align:left">validity_day_of_week</td><td style="text-align:left">See: <a href="#validity-day-of-week">Validity Day Of Week</a></td></tr><tr><td style="text-align:left">validity_hours</td><td style="text-align:left">See: <a href="#validity-hours">Validity Hours</a></td></tr><tr><td style="text-align:left">active</br><code>boolean</code></td><td style="text-align:left"><p>A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the <code>start_date</code> and <code>expiration_date</code> using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) --><a href="ref:disable-campaign">Disable Campaign</a> endpoint.</p><ul><li><code>true</code> indicates an <em>active</em> campaign</li><li><code>false</code> indicates an <em>inactive</em> campaign</li></ul></td></tr><tr><td style="text-align:left">category_id</br><code>string</code></td><td style="text-align:left"><p>Unique category ID that this campaign belongs to.</p> <strong>Example:</strong> <p>cat_0b688929a2476386a6</p></td></tr><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>The type of the object represented by the campaign object. This object stores information about the campaign.</p></td></tr></tbody></table> |
+| campaign_id</br>`string` | <p>Promotion tier's parent campaign's unique ID.</p> |
+| active</br>`boolean` | <p>A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the <code>start_date</code> and <code>expiration_date</code>.</p><ul><li><code>true</code> indicates an <em>active</em> promotion tier</li><li><code>false</code> indicates an <em>inactive</em> promotion tier</li></ul> |
+| start_date</br>`string` | <p>Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is <em>inactive before</em> this date.</p> **Example:** <p>2022-09-23T00:00:00.000Z</p> |
+| expiration_date</br>`string` | <p>Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is <em>inactive after</em> this date.</p> **Example:** <p>2022-09-26T00:00:00.000Z</p> |
+| validity_timeframe | See: [Validity Timeframe](#validity-timeframe) |
+| validity_day_of_week | See: [Validity Day Of Week](#validity-day-of-week) |
+| validity_hours | See: [Validity Hours](#validity-hours) |
+| summary</br>`object` | <p>Contains statistics about promotion tier redemptions and orders.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">redemptions</br><code>object</code></td><td style="text-align:left"><p>Contains statistics about promotion tier redemptions.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">total_redeemed</br><code>integer</code></td><td style="text-align:left"><p>Number of times the promotion tier was redeemed.</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">orders</br><code>object</code></td><td style="text-align:left"><p>Contains statistics about orders related to the promotion tier.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">total_amount</br><code>integer</code></td><td style="text-align:left"><p>Sum of order totals.</p></td></tr><tr><td style="text-align:left">total_discount_amount</br><code>integer</code></td><td style="text-align:left"><p>Sum of total discount applied using the promotion tier.</p></td></tr></tbody></table></td></tr></tbody></table> |
+| object</br>`string` | <p>The type of the object represented by JSON. This object stores information about the promotion tier.</p> |
+| validation_rule_assignments | See: [Validation Rule Assignments List](#validation-rule-assignments-list) |
+| category_id</br>`string` | <p>Promotion tier category ID.</p> **Example:** <p>cat_0c9da30e7116ba6bba</p> |
+| categories</br>`array` | Array of [Category](#category) |
+
+## Redemption Reward Result
+| Attributes |  Description |
+|:-----|:--------|
+| customer | [Simple Customer](#simple-customer) |
+| assignment_id</br>`string`, `null` | <p>Unique reward assignment ID assigned by Voucherify.</p> |
+| voucher | [Voucher](#voucher) |
+| product | [Product](#product) |
+| sku | [SKU Object](#sku-object) |
+| loyalty_tier_id</br>`string`, `null` | <p>Unique loyalty tier ID assigned by Voucherify.</p> |
+| id</br>`string` | <p>Unique reward ID.</p> **Example:** <p>rew_0bc92f81a6801f9bca</p> |
+| name</br>`string` | <p>Name of the reward.</p> **Example:** <p>Reward Name</p> |
+| object</br>`string` | <p>The type of the object represented by the JSON</p> Available values: `reward` |
+| created_at</br>`string` | <p>Timestamp representing the date and time when the redemption was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-22T10:13:06.487Z</p> |
+| updated_at</br>`string` | <p>Timestamp in ISO 8601 format indicating when the reward was updated.</p> **Example:** <p>2022-10-03T12:24:58.008Z</p> |
+| parameters</br>`object` | <p>These are parameters representing a material reward.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">campaign</br><code>object</code></td><td style="text-align:left"><p>Defines the product redeemed as a reward.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Campaign unique ID.</p> <strong>Example:</strong> <p>camp_13BbZ0kQsNinhqsX3wUts2UP</p></td></tr><tr><td style="text-align:left">balance</br><code>integer</code></td><td style="text-align:left"><p>Points available for reward redemption.</p></td></tr><tr><td style="text-align:left">type</br><code>string</code></td><td style="text-align:left"><p>Defines the type of the campaign.</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">product</br><code>object</code></td><td style="text-align:left"><p>Defines the product redeemed as a reward.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique product ID, assigned by Voucherify.</p> <strong>Example:</strong> <p>prod_0b7d7dfb05cbe5c616</p></td></tr><tr><td style="text-align:left">sku_id</br><code>string</code></td><td style="text-align:left"><p>Unique identifier of the SKU. It is assigned by Voucherify.</p> <strong>Example:</strong> <p>sku_0a41e31c7b41c28358</p></td></tr></tbody></table></td></tr><tr><td style="text-align:left">coin</br><code>object</code></td><td style="text-align:left"><p>Defines the ratio by mapping the number of loyalty points in <code>points_ratio</code> to a predefined cash amount in <code>exchange_ratio</code>.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">exchange_ratio</br><code>integer</code></td><td style="text-align:left"><p>The cash equivalent of the points defined in the <code>points_ratio</code> property.</p></td></tr><tr><td style="text-align:left">points_ratio</br><code>integer</code></td><td style="text-align:left"><p>The number of loyalty points that will map to the predefined cash amount defined by the <code>exchange_ratio</code> property.</p></td></tr></tbody></table></td></tr></tbody></table> |
+| metadata</br>`object` | <p>A set of custom key/value pairs that you can attach to a reward. The metadata object stores all custom attributes assigned to the reward.</p> |
+| type</br>`string` | <p>Reward type.</p> Available values: `CAMPAIGN`, `COIN`, `MATERIAL` |
+
 ## Voucher Base
 | Attributes |  Description |
 |:-----|:--------|
@@ -290,6 +296,14 @@ All of:
 | publish</br>`object` | <p>Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>The type of the object represented is by default <code>list</code>. To get this list, you need to make a call to the endpoint returned in the <code>url</code> attribute.</p></td></tr><tr><td style="text-align:left">count</br><code>integer</code></td><td style="text-align:left"><p>Publication events counter.</p> <strong>Example:</strong> <p>0</p></td></tr><tr><td style="text-align:left">url</br><code>string</code></td><td style="text-align:left"><p>The endpoint where this list of publications can be accessed using a GET method. <code>/v1/vouchers/{voucher_code}/publications</code></p> <strong>Example:</strong> <p>/v1/vouchers/WVPblOYX/publications?page=1&amp;limit=10</p></td></tr></tbody></table> |
 | redemption</br>`object` | <p>Stores a summary of redemptions that have been applied to the voucher.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">quantity</br><code>integer</code></td><td style="text-align:left"><p>How many times a voucher can be redeemed. A <code>null</code> value means unlimited.</p></td></tr><tr><td style="text-align:left">redeemed_quantity</br><code>integer</code></td><td style="text-align:left"><p>How many times a voucher has already been redeemed.</p> <strong>Example:</strong> <p>1</p></td></tr><tr><td style="text-align:left">redeemed_points</br><code>integer</code></td><td style="text-align:left"><p>Total loyalty points redeemed.</p> <strong>Example:</strong> <p>100000</p></td></tr><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>The type of the object represented is by default <code>list</code>. To get this list, you need to make a call to the endpoint returned in the url attribute.</p></td></tr><tr><td style="text-align:left">url</br><code>string</code></td><td style="text-align:left"><p>The endpoint where this list of redemptions can be accessed using a GET method. <code>/v1/vouchers/{voucher_code}/redemptions</code></p> <strong>Example:</strong> <p>/v1/vouchers/WVPblOYX/redemptions?page=1&amp;limit=10</p></td></tr></tbody></table> |
 
+## Validation Rules Assignments List
+| Attributes |  Description |
+|:-----|:--------|
+| object</br>`string` | <p>The type of the object represented by JSON. This object stores information about validation rules assignments.</p> Available values: `list` |
+| data_ref</br>`string` | <p>Identifies the name of the attribute that contains the array of validation rules assignments.</p> Available values: `data` |
+| data</br>`array` | <p>Contains array of validation rules assignments.</p> Array of [Business Validation Rule Assignment](#business-validation-rule-assignment) |
+| total</br>`integer` | <p>Total number of validation rules assignments.</p> |
+
 ## Category
 | Attributes |  Description |
 |:-----|:--------|
@@ -299,14 +313,6 @@ All of:
 | object</br>`string` | <p>The type of the object represented by the JSON. This object stores information about the category.</p> Available values: `category` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the category was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-07-14T10:45:13.156Z</p> |
 | updated_at</br>`string` | <p>Timestamp representing the date and time when the category was updated. The value is shown in the ISO 8601 format.</p> **Example:** <p>2022-08-16T10:52:08.094Z</p> |
-
-## Validation Rules Assignments List
-| Attributes |  Description |
-|:-----|:--------|
-| object</br>`string` | <p>The type of the object represented by JSON. This object stores information about validation rules assignments.</p> Available values: `list` |
-| data_ref</br>`string` | <p>Identifies the name of the attribute that contains the array of validation rules assignments.</p> Available values: `data` |
-| data</br>`array` | <p>Contains array of validation rules assignments.</p> Array of [Business Validation Rule Assignment](#business-validation-rule-assignment) |
-| total</br>`integer` | <p>Total number of validation rules assignments.</p> |
 
 ## Discount
 <p>Contains information about discount.</p>
@@ -336,6 +342,14 @@ One of:
 | data_ref</br>`string` | <p>Identifies the name of the JSON property that contains the array of validation rule assignments.</p> |
 | data</br>`array` | <p>A dictionary that contains an array of validation rule assignments.</p> Array of [Validation Rule Assignment](#validation-rule-assignment) |
 | total</br>`integer` | <p>Total number of validation rule assignments.</p> |
+
+## Voucher
+<p>This is an object representing a voucher with categories and validation rules assignments.</p>
+
+All of:
+
+1. [Voucher Base](#voucher-base)
+2. <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">categories</br><code>array</code></td><td style="text-align:left"><p>Contains details about the category.</p> Array of <a href="#category">Category</a></td></tr><tr><td style="text-align:left">validation_rules_assignments</td><td style="text-align:left">See: <a href="#validation-rules-assignments-list">Validation Rules Assignments List</a></td></tr></tbody></table>
 
 ## Product
 <p>This is an object representing a product.</p><p>This entity should be used to map product items from your inventory management system. The aim of products is to build which reflect product-specific campaigns.</p>

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -3441,12 +3441,12 @@
           "redemptions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "description": "Contains the order details associated with the redemption.",
@@ -10420,7 +10420,7 @@
         "description": "Response body schema for **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption` and for **POST** `v1/loyalties/members/{memberId}/redemption`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/MembersRedemption"
           },
           {
             "title": "RedemptionRewardRequired",
@@ -11246,6 +11246,30 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/Reward"
+          }
+        ]
+      },
+      "LoyaltiesRewardRedemption": {
+        "title": "Member Card",
+        "readmeTitle": "Member card with categories and validation rules assignments",
+        "description": "This is an object representing a member card with categories and validation rules assignments.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoucherBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "categories": {
+                "type": "array",
+                "description": "Always returns an empty array.",
+                "items": {},
+                "nullable": true
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              }
+            }
           }
         ]
       },
@@ -14824,6 +14848,32 @@
           },
           {
             "$ref": "#/components/schemas/EventCustomerVouchersLoyaltyPointsExpired"
+          }
+        ]
+      },
+      "MembersRedemption": {
+        "title": "Redemption",
+        "type": "object",
+        "description": "This is an object representing a redemption.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RedemptionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "voucher": {
+                "description": "Defines the details of the voucher being redeemed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LoyaltiesRewardRedemption"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VoucherHolder"
+                  }
+                ]
+              }
+            }
           }
         ]
       },
@@ -20602,6 +20652,31 @@
         "title": "Redemption",
         "type": "object",
         "description": "This is an object representing a redemption.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RedemptionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "voucher": {
+                "description": "Defines the details of the voucher being redeemed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Voucher"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VoucherHolder"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "RedemptionBase": {
+        "title": "Redemption Base",
+        "type": "object",
         "properties": {
           "id": {
             "type": "string",
@@ -20783,17 +20858,6 @@
             "type": "string",
             "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
             "nullable": true
-          },
-          "voucher": {
-            "description": "Defines the details of the voucher being redeemed.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Voucher"
-              },
-              {
-                "$ref": "#/components/schemas/VoucherHolder"
-              }
-            ]
           },
           "promotion_tier": {
             "description": "Contains details of the promotion tier and the parent campaign.",
@@ -21055,6 +21119,32 @@
             ]
           }
         }
+      },
+      "RedemptionRedeem": {
+        "title": "Redemption Redeem",
+        "type": "object",
+        "description": "This is an object representing a redemption for **POST** `v1/redemptions`, **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption`, **POST** `v1/loyalties/members/{memberId}/redemption`, **POST** `/client/v1/redemptions`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RedemptionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "voucher": {
+                "description": "Defines the details of the voucher being redeemed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/VoucherQualificationValidationRedemption"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VoucherHolder"
+                  }
+                ]
+              }
+            }
+          }
+        ]
       },
       "RedemptionRewardResult": {
         "title": "Redemption Reward Result",
@@ -21555,12 +21645,12 @@
           "redemptions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "description": "Contains the order details associated with the redemption.",
@@ -26936,6 +27026,32 @@
             "required": [
               "loyalty_card"
             ]
+          }
+        ]
+      },
+      "VoucherQualificationValidationRedemption": {
+        "title": "Voucher",
+        "readmeTitle": "Voucher with categories and validation rules assignments",
+        "description": "This is an object representing a voucher with categories and validation rules assignments for **POST** `v1/qualifications`, **POST** `v1/redemptions`, and **POST** `v1/validations`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoucherBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "categories": {
+                "type": "array",
+                "description": "Contains details about the category.",
+                "items": {
+                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                },
+                "nullable": true
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              }
+            }
           }
         ]
       },

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -27044,7 +27044,7 @@
                 "type": "array",
                 "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                  "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                 },
                 "nullable": true
               },

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -4147,6 +4147,29 @@
           }
         ]
       },
+      "LoyaltiesRewardRedemption": {
+        "title": "Member Card",
+        "readmeTitle": "Member card with categories and validation rules assignments",
+        "description": "This is an object representing a member card with categories and validation rules assignments.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoucherBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "categories": {
+                "type": "array",
+                "description": "Always returns an empty array.",
+                "items": {}
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              }
+            }
+          }
+        ]
+      },
       "Voucher": {
         "title": "Voucher",
         "readmeTitle": "Voucher with categories and validation rules assignments",
@@ -16457,11 +16480,11 @@
           "redemptions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             }
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "description": "Contains the order details associated with the redemption.",
@@ -17752,10 +17775,87 @@
           "related_object_id"
         ]
       },
+      "MembersRedemption": {
+        "title": "Redemption",
+        "type": "object",
+        "description": "This is an object representing a redemption.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RedemptionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "voucher": {
+                "description": "Defines the details of the voucher being redeemed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LoyaltiesRewardRedemption"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VoucherHolder"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "RedemptionRedeem": {
+        "title": "Redemption Redeem",
+        "type": "object",
+        "description": "This is an object representing a redemption for **POST** `v1/redemptions`, **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption`, **POST** `v1/loyalties/members/{memberId}/redemption`, **POST** `/client/v1/redemptions`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RedemptionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "voucher": {
+                "description": "Defines the details of the voucher being redeemed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/VoucherQualificationValidationRedemption"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VoucherHolder"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
       "Redemption": {
         "title": "Redemption",
         "type": "object",
         "description": "This is an object representing a redemption.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RedemptionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "voucher": {
+                "description": "Defines the details of the voucher being redeemed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Voucher"
+                  },
+                  {
+                    "$ref": "#/components/schemas/VoucherHolder"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "RedemptionBase": {
+        "title": "Redemption Base",
+        "type": "object",
         "properties": {
           "id": {
             "type": "string",
@@ -17921,17 +18021,6 @@
           "related_object_id": {
             "type": "string",
             "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher."
-          },
-          "voucher": {
-            "description": "Defines the details of the voucher being redeemed.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Voucher"
-              },
-              {
-                "$ref": "#/components/schemas/VoucherHolder"
-              }
-            ]
           },
           "promotion_tier": {
             "description": "Contains details of the promotion tier and the parent campaign.",
@@ -38978,11 +39067,11 @@
           "redemptions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             }
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "description": "Contains the order details associated with the redemption.",
@@ -39600,7 +39689,7 @@
         "description": "Response body schema for **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption` and for **POST** `v1/loyalties/members/{memberId}/redemption`.",
         "allOf": [
           {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/MembersRedemption"
           },
           {
             "title": "RedemptionRewardRequired",

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -2594,12 +2594,12 @@
             "title": "ClientRedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -9408,6 +9408,38 @@
             "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
             "nullable": true
           },
+          "promotion_tier": {
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucher",
             "description": "Defines the details of the voucher being redeemed.",
@@ -9667,9 +9699,9 @@
               "categories": {
                 "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucherCategories",
                 "type": "array",
-                "description": "Contains details about the category.",
+                "description": "Always returns an empty array.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "title": "MembersRedemptionVoucherCategoriesItem"
                 },
                 "nullable": true
               },
@@ -9678,38 +9710,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
               }
             },
             "nullable": true
@@ -21429,6 +21429,239 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionsGetResponseBodyPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionsGetResponseBodyPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "$ref": "#/components/schemas/ValidityDayOfWeek"
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "$ref": "#/components/schemas/ValidityDayOfWeek"
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionsGetResponseBodyGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionsGetResponseBodyLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionsGetResponseBodyVoucher",
             "type": "object",
@@ -21693,239 +21926,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "title": "RedemptionsGetResponseBodyPromotionTier",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
-                "nullable": true
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionsGetResponseBodyPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
-                "nullable": true
-              },
-              "campaign": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "$ref": "#/components/schemas/ValidityDayOfWeek"
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
-                "nullable": true
-              },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "$ref": "#/components/schemas/ValidityDayOfWeek"
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "summary": {
-                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
-                "type": "object",
-                "properties": {
-                  "redemptions": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  },
-                  "orders": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionsGetResponseBodyGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionsGetResponseBodyLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
               }
             },
             "nullable": true
@@ -22312,6 +22312,228 @@
                 "related_object_id": {
                   "type": "string"
                 },
+                "promotion_tier": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                      "description": "Unique promotion tier ID.",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "example": "2021-12-15T11:34:01.333Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2022-02-09T09:20:05.603Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the promotion tier.",
+                      "nullable": true
+                    },
+                    "banner": {
+                      "type": "string",
+                      "description": "Text to be displayed to your customers on your website.",
+                      "nullable": true
+                    },
+                    "action": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
+                      "type": "object",
+                      "properties": {
+                        "discount": {
+                          "$ref": "#/components/schemas/Discount"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
+                      "type": "object"
+                    },
+                    "hierarchy": {
+                      "type": "integer",
+                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                      "nullable": true
+                    },
+                    "promotion_id": {
+                      "type": "string",
+                      "description": "Promotion unique ID.",
+                      "nullable": true
+                    },
+                    "campaign": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique campaign ID.",
+                          "nullable": true
+                        },
+                        "start_date": {
+                          "type": "string",
+                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                          "format": "date-time",
+                          "example": "2022-09-22T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "expiration_date": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                          "example": "2022-09-30T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "validity_timeframe": {
+                          "$ref": "#/components/schemas/ValidityTimeframe"
+                        },
+                        "validity_day_of_week": {
+                          "$ref": "#/components/schemas/ValidityDayOfWeek"
+                        },
+                        "validity_hours": {
+                          "$ref": "#/components/schemas/ValidityHours"
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                          "nullable": true
+                        },
+                        "category_id": {
+                          "type": "string",
+                          "example": "cat_0b688929a2476386a6",
+                          "description": "Unique category ID that this campaign belongs to.",
+                          "nullable": true
+                        },
+                        "object": {
+                          "type": "string",
+                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                          "default": "campaign",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "campaign_id": {
+                      "type": "string",
+                      "description": "Promotion tier's parent campaign's unique ID.",
+                      "nullable": true
+                    },
+                    "active": {
+                      "type": "boolean",
+                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                      "nullable": true
+                    },
+                    "start_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-23T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "expiration_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-26T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "validity_timeframe": {
+                      "$ref": "#/components/schemas/ValidityTimeframe"
+                    },
+                    "validity_day_of_week": {
+                      "$ref": "#/components/schemas/ValidityDayOfWeek"
+                    },
+                    "validity_hours": {
+                      "$ref": "#/components/schemas/ValidityHours"
+                    },
+                    "summary": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
+                      "type": "object",
+                      "properties": {
+                        "redemptions": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
+                          "type": "object",
+                          "properties": {
+                            "total_redeemed": {
+                              "type": "integer",
+                              "description": "Number of times the promotion tier was redeemed.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "orders": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
+                          "type": "object",
+                          "properties": {
+                            "total_amount": {
+                              "type": "integer",
+                              "description": "Sum of order totals.",
+                              "nullable": true
+                            },
+                            "total_discount_amount": {
+                              "type": "integer",
+                              "description": "Sum of total discount applied using the promotion tier.",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object": {
+                      "type": "string",
+                      "default": "promotion_tier",
+                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                      "nullable": true
+                    },
+                    "validation_rule_assignments": {
+                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+                    },
+                    "category_id": {
+                      "type": "string",
+                      "description": "Promotion tier category ID.",
+                      "example": "cat_0c9da30e7116ba6bba",
+                      "nullable": true
+                    },
+                    "categories": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Category"
+                      },
+                      "nullable": true
+                    }
+                  }
+                },
+                "reward": {
+                  "$ref": "#/components/schemas/RedemptionRewardResult"
+                },
+                "gift": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "integer",
+                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+                    }
+                  }
+                },
+                "loyalty_card": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
+                  "type": "object",
+                  "properties": {
+                    "points": {
+                      "type": "integer",
+                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+                    }
+                  }
+                },
                 "voucher": {
                   "title": "RedemptionsListResponseBodyRedemptionsItemVoucher",
                   "type": "object",
@@ -22574,228 +22796,6 @@
                     }
                   }
                 },
-                "promotion_tier": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                      "description": "Unique promotion tier ID.",
-                      "nullable": true
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "example": "2021-12-15T11:34:01.333Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "example": "2022-02-09T09:20:05.603Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Name of the promotion tier.",
-                      "nullable": true
-                    },
-                    "banner": {
-                      "type": "string",
-                      "description": "Text to be displayed to your customers on your website.",
-                      "nullable": true
-                    },
-                    "action": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
-                      "type": "object",
-                      "properties": {
-                        "discount": {
-                          "$ref": "#/components/schemas/Discount"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
-                      "type": "object"
-                    },
-                    "hierarchy": {
-                      "type": "integer",
-                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                      "nullable": true
-                    },
-                    "promotion_id": {
-                      "type": "string",
-                      "description": "Promotion unique ID.",
-                      "nullable": true
-                    },
-                    "campaign": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "Unique campaign ID.",
-                          "nullable": true
-                        },
-                        "start_date": {
-                          "type": "string",
-                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                          "format": "date-time",
-                          "example": "2022-09-22T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "expiration_date": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                          "example": "2022-09-30T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "validity_timeframe": {
-                          "$ref": "#/components/schemas/ValidityTimeframe"
-                        },
-                        "validity_day_of_week": {
-                          "$ref": "#/components/schemas/ValidityDayOfWeek"
-                        },
-                        "validity_hours": {
-                          "$ref": "#/components/schemas/ValidityHours"
-                        },
-                        "active": {
-                          "type": "boolean",
-                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                          "nullable": true
-                        },
-                        "category_id": {
-                          "type": "string",
-                          "example": "cat_0b688929a2476386a6",
-                          "description": "Unique category ID that this campaign belongs to.",
-                          "nullable": true
-                        },
-                        "object": {
-                          "type": "string",
-                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                          "default": "campaign",
-                          "nullable": true
-                        }
-                      }
-                    },
-                    "campaign_id": {
-                      "type": "string",
-                      "description": "Promotion tier's parent campaign's unique ID.",
-                      "nullable": true
-                    },
-                    "active": {
-                      "type": "boolean",
-                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                      "nullable": true
-                    },
-                    "start_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-23T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "expiration_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-26T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "validity_timeframe": {
-                      "$ref": "#/components/schemas/ValidityTimeframe"
-                    },
-                    "validity_day_of_week": {
-                      "$ref": "#/components/schemas/ValidityDayOfWeek"
-                    },
-                    "validity_hours": {
-                      "$ref": "#/components/schemas/ValidityHours"
-                    },
-                    "summary": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
-                      "type": "object",
-                      "properties": {
-                        "redemptions": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
-                          "type": "object",
-                          "properties": {
-                            "total_redeemed": {
-                              "type": "integer",
-                              "description": "Number of times the promotion tier was redeemed.",
-                              "nullable": true
-                            }
-                          }
-                        },
-                        "orders": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
-                          "type": "object",
-                          "properties": {
-                            "total_amount": {
-                              "type": "integer",
-                              "description": "Sum of order totals.",
-                              "nullable": true
-                            },
-                            "total_discount_amount": {
-                              "type": "integer",
-                              "description": "Sum of total discount applied using the promotion tier.",
-                              "nullable": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "object": {
-                      "type": "string",
-                      "default": "promotion_tier",
-                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                      "nullable": true
-                    },
-                    "validation_rule_assignments": {
-                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-                    },
-                    "category_id": {
-                      "type": "string",
-                      "description": "Promotion tier category ID.",
-                      "example": "cat_0c9da30e7116ba6bba",
-                      "nullable": true
-                    },
-                    "categories": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Category"
-                      },
-                      "nullable": true
-                    }
-                  }
-                },
-                "reward": {
-                  "$ref": "#/components/schemas/RedemptionRewardResult"
-                },
-                "gift": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "integer",
-                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-                    }
-                  }
-                },
-                "loyalty_card": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
-                  "type": "object",
-                  "properties": {
-                    "points": {
-                      "type": "integer",
-                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-                    }
-                  }
-                },
                 "reason": {
                   "type": "string",
                   "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
@@ -22927,12 +22927,12 @@
             "title": "RedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -35241,496 +35241,6 @@
         },
         "required": []
       },
-      "Redemption": {
-        "title": "Redemption",
-        "type": "object",
-        "description": "This is an object representing a redemption.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "r_0bc92f81a6801f9bca",
-            "description": "Unique redemption ID.",
-            "nullable": true
-          },
-          "object": {
-            "type": "string",
-            "description": "The type of the object represented by the JSON",
-            "default": "redemption",
-            "enum": [
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "date": {
-            "type": "string",
-            "example": "2021-12-22T10:13:06.487Z",
-            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "customer_id": {
-            "type": "string",
-            "nullable": true,
-            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
-            "description": "Unique customer ID of the redeeming customer."
-          },
-          "tracking_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "Hashed customer source ID."
-          },
-          "metadata": {
-            "title": "RedemptionMetadata",
-            "type": "object",
-            "nullable": true,
-            "description": "The metadata object stores all custom attributes assigned to the redemption."
-          },
-          "amount": {
-            "type": "integer",
-            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
-            "example": 10000,
-            "nullable": true
-          },
-          "redemption": {
-            "nullable": true,
-            "type": "string",
-            "description": "Unique redemption ID of the parent redemption.",
-            "example": "r_0c656311b5878a2031"
-          },
-          "result": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILURE"
-            ],
-            "description": "Redemption result.",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "SUCCEEDED",
-              "FAILED",
-              "ROLLED_BACK"
-            ],
-            "description": "Redemption status.",
-            "nullable": true
-          },
-          "related_redemptions": {
-            "title": "RedemptionRelatedRedemptions",
-            "type": "object",
-            "properties": {
-              "rollbacks": {
-                "title": "RedemptionRelatedRedemptionsRollbacks",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRollbacksItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "rr_0bc92f81a6801f9bca",
-                      "description": "Unique rollback redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              },
-              "redemptions": {
-                "title": "RedemptionRelatedRedemptionsRedemptions",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRedemptionsItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "r_0bc92f81a6801f9bca",
-                      "description": "Unique redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "failure_code": {
-            "type": "string",
-            "example": "customer_rules_violated",
-            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "failure_message": {
-            "type": "string",
-            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "order": {
-            "$ref": "#/components/schemas/OrderCalculated"
-          },
-          "channel": {
-            "title": "RedemptionChannel",
-            "type": "object",
-            "description": "Defines the details of the channel through which the redemption was issued.",
-            "properties": {
-              "channel_id": {
-                "type": "string",
-                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
-                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
-                "nullable": true
-              },
-              "channel_type": {
-                "type": "string",
-                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
-                "enum": [
-                  "USER",
-                  "API"
-                ],
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "customer": {
-            "$ref": "#/components/schemas/SimpleCustomer"
-          },
-          "related_object_type": {
-            "type": "string",
-            "description": "Defines the related object.",
-            "enum": [
-              "voucher",
-              "promotion_tier",
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "related_object_id": {
-            "type": "string",
-            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
-            "nullable": true
-          },
-          "voucher": {
-            "title": "RedemptionVoucher",
-            "description": "Defines the details of the voucher being redeemed.",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
-                "description": "Assigned by the Voucherify API, identifies the voucher.",
-                "nullable": true
-              },
-              "code": {
-                "type": "string",
-                "example": "WVPblOYX",
-                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
-                "nullable": true
-              },
-              "campaign": {
-                "type": "string",
-                "example": "Gift Card Campaign",
-                "description": "A unique campaign name, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
-                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "category": {
-                "type": "string",
-                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
-                "nullable": true
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Unique category ID assigned by Voucherify.",
-                "example": "cat_0bb343dee3cdb5ec0c",
-                "nullable": true
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "GIFT_VOUCHER",
-                  "DISCOUNT_VOUCHER",
-                  "LOYALTY_CARD"
-                ],
-                "description": "Defines the type of the voucher. ",
-                "nullable": true
-              },
-              "discount": {
-                "$ref": "#/components/schemas/Discount"
-              },
-              "gift": {
-                "title": "RedemptionVoucherGift",
-                "type": "object",
-                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
-                "properties": {
-                  "amount": {
-                    "type": "integer",
-                    "example": 10000,
-                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 500,
-                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "effect": {
-                    "type": "string",
-                    "enum": [
-                      "APPLY_TO_ORDER",
-                      "APPLY_TO_ITEMS"
-                    ],
-                    "description": "Defines how the credits are applied to the customer's order.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "loyalty_card": {
-                "title": "RedemptionVoucherLoyaltyCard",
-                "type": "object",
-                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
-                "properties": {
-                  "points": {
-                    "type": "integer",
-                    "example": 7000,
-                    "description": "Total points incurred over the lifespan of the loyalty card.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 6970,
-                    "description": "Points available for reward redemption.",
-                    "nullable": true
-                  },
-                  "next_expiration_date": {
-                    "type": "string",
-                    "format": "date",
-                    "example": "2023-05-30",
-                    "description": "The next closest date when the next set of points are due to expire.",
-                    "nullable": true
-                  },
-                  "next_expiration_points": {
-                    "type": "integer",
-                    "description": "The amount of points that are set to expire next.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "example": "2021-12-01T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "example": "2021-12-31T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "$ref": "#/components/schemas/ValidityDayOfWeek"
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "active": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
-              },
-              "additional_info": {
-                "type": "string",
-                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionVoucherMetadata",
-                "type": "object",
-                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
-                "nullable": true
-              },
-              "assets": {
-                "$ref": "#/components/schemas/VoucherAssets"
-              },
-              "is_referral_code": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-22T10:13:06.487Z",
-                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
-                "format": "date-time",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2021-12-22T10:14:45.316Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
-                "nullable": true
-              },
-              "holder_id": {
-                "type": "string",
-                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
-                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
-                "nullable": true
-              },
-              "referrer_id": {
-                "type": "string",
-                "description": "Unique identifier of the referring person.",
-                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "description": "The type of the object represented by JSON. Default is `voucher`.",
-                "default": "voucher",
-                "nullable": true
-              },
-              "publish": {
-                "title": "RedemptionVoucherPublish",
-                "type": "object",
-                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
-                "properties": {
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
-                    "nullable": true
-                  },
-                  "count": {
-                    "type": "integer",
-                    "example": 0,
-                    "description": "Publication events counter.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
-                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "redemption": {
-                "title": "RedemptionVoucherRedemption",
-                "type": "object",
-                "description": "Stores a summary of redemptions that have been applied to the voucher.",
-                "properties": {
-                  "quantity": {
-                    "type": "integer",
-                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
-                    "nullable": true
-                  },
-                  "redeemed_quantity": {
-                    "type": "integer",
-                    "example": 1,
-                    "description": "How many times a voucher has already been redeemed.",
-                    "nullable": true
-                  },
-                  "redeemed_points": {
-                    "type": "integer",
-                    "example": 100000,
-                    "description": "Total loyalty points redeemed.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
-                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionVoucherCategories",
-                "type": "array",
-                "description": "Contains details about the category.",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              },
-              "validation_rules_assignments": {
-                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
-              },
-              "holder": {
-                "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          }
-        },
-        "required": []
-      },
       "RedemptionEntry": {
         "title": "RedemptionEntry",
         "type": "object",
@@ -36103,6 +35613,239 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionEntryPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionEntryPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionEntryPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionEntryPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "$ref": "#/components/schemas/ValidityDayOfWeek"
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "$ref": "#/components/schemas/ValidityDayOfWeek"
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionEntryPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionEntryPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionEntryPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionEntryGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionEntryLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionEntryVoucher",
             "type": "object",
@@ -36371,139 +36114,351 @@
             },
             "nullable": true
           },
+          "reason": {
+            "type": "string",
+            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
+            "nullable": true
+          }
+        }
+      },
+      "RedemptionRedeem": {
+        "title": "RedemptionRedeem",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "r_0bc92f81a6801f9bca",
+            "description": "Unique redemption ID.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "description": "The type of the object represented by the JSON",
+            "default": "redemption",
+            "enum": [
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "example": "2021-12-22T10:13:06.487Z",
+            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "customer_id": {
+            "type": "string",
+            "nullable": true,
+            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
+            "description": "Unique customer ID of the redeeming customer."
+          },
+          "tracking_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Hashed customer source ID."
+          },
+          "metadata": {
+            "title": "RedemptionRedeemMetadata",
+            "type": "object",
+            "nullable": true,
+            "description": "The metadata object stores all custom attributes assigned to the redemption."
+          },
+          "amount": {
+            "type": "integer",
+            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
+            "example": 10000,
+            "nullable": true
+          },
+          "redemption": {
+            "nullable": true,
+            "type": "string",
+            "description": "Unique redemption ID of the parent redemption.",
+            "example": "r_0c656311b5878a2031"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILURE"
+            ],
+            "description": "Redemption result.",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUCCEEDED",
+              "FAILED",
+              "ROLLED_BACK"
+            ],
+            "description": "Redemption status.",
+            "nullable": true
+          },
+          "related_redemptions": {
+            "title": "RedemptionRedeemRelatedRedemptions",
+            "type": "object",
+            "properties": {
+              "rollbacks": {
+                "title": "RedemptionRedeemRelatedRedemptionsRollbacks",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRollbacksItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "rr_0bc92f81a6801f9bca",
+                      "description": "Unique rollback redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              },
+              "redemptions": {
+                "title": "RedemptionRedeemRelatedRedemptionsRedemptions",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRedemptionsItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "r_0bc92f81a6801f9bca",
+                      "description": "Unique redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "failure_code": {
+            "type": "string",
+            "example": "customer_rules_violated",
+            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "failure_message": {
+            "type": "string",
+            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "order": {
+            "$ref": "#/components/schemas/OrderCalculated"
+          },
+          "channel": {
+            "title": "RedemptionRedeemChannel",
+            "type": "object",
+            "description": "Defines the details of the channel through which the redemption was issued.",
+            "properties": {
+              "channel_id": {
+                "type": "string",
+                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
+                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
+                "nullable": true
+              },
+              "channel_type": {
+                "type": "string",
+                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
+                "enum": [
+                  "USER",
+                  "API"
+                ],
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "customer": {
+            "$ref": "#/components/schemas/SimpleCustomer"
+          },
+          "related_object_type": {
+            "type": "string",
+            "description": "Defines the related object.",
+            "enum": [
+              "voucher",
+              "promotion_tier",
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "related_object_id": {
+            "type": "string",
+            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
+            "nullable": true
+          },
           "promotion_tier": {
-            "title": "RedemptionEntryPromotionTier",
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionRedeemGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionRedeemLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "voucher": {
+            "title": "RedemptionRedeemVoucher",
+            "description": "Defines the details of the voucher being redeemed.",
             "type": "object",
             "properties": {
               "id": {
                 "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
+                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
+                "description": "Assigned by the Voucherify API, identifies the voucher.",
                 "nullable": true
               },
-              "created_at": {
+              "code": {
                 "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionEntryPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionEntryPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
+                "example": "WVPblOYX",
+                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
                 "nullable": true
               },
               "campaign": {
-                "title": "RedemptionEntryPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "$ref": "#/components/schemas/ValidityDayOfWeek"
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
+                "type": "string",
+                "example": "Gift Card Campaign",
+                "description": "A unique campaign name, identifies the voucher's parent campaign.",
                 "nullable": true
               },
               "campaign_id": {
                 "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
+                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
+                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
                 "nullable": true
               },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+              "category": {
+                "type": "string",
+                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
+                "nullable": true
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Unique category ID assigned by Voucherify.",
+                "example": "cat_0bb343dee3cdb5ec0c",
+                "nullable": true
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "GIFT_VOUCHER",
+                  "DISCOUNT_VOUCHER",
+                  "LOYALTY_CARD"
+                ],
+                "description": "Defines the type of the voucher. ",
+                "nullable": true
+              },
+              "discount": {
+                "$ref": "#/components/schemas/Discount"
+              },
+              "gift": {
+                "title": "RedemptionRedeemVoucherGift",
+                "type": "object",
+                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
+                "properties": {
+                  "amount": {
+                    "type": "integer",
+                    "example": 10000,
+                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 500,
+                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "effect": {
+                    "type": "string",
+                    "enum": [
+                      "APPLY_TO_ORDER",
+                      "APPLY_TO_ITEMS"
+                    ],
+                    "description": "Defines how the credits are applied to the customer's order.",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "loyalty_card": {
+                "title": "RedemptionRedeemVoucherLoyaltyCard",
+                "type": "object",
+                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
+                "properties": {
+                  "points": {
+                    "type": "integer",
+                    "example": 7000,
+                    "description": "Total points incurred over the lifespan of the loyalty card.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 6970,
+                    "description": "Points available for reward redemption.",
+                    "nullable": true
+                  },
+                  "next_expiration_date": {
+                    "type": "string",
+                    "format": "date",
+                    "example": "2023-05-30",
+                    "description": "The next closest date when the next set of points are due to expire.",
+                    "nullable": true
+                  },
+                  "next_expiration_points": {
+                    "type": "integer",
+                    "description": "The amount of points that are set to expire next.",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "start_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "example": "2021-12-01T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
+                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
                 "nullable": true
               },
               "expiration_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "example": "2021-12-31T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
+                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
                 "nullable": true
               },
               "validity_timeframe": {
@@ -36515,101 +36470,145 @@
               "validity_hours": {
                 "$ref": "#/components/schemas/ValidityHours"
               },
-              "summary": {
-                "title": "RedemptionEntryPromotionTierSummary",
+              "active": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
+              },
+              "additional_info": {
+                "type": "string",
+                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionRedeemVoucherMetadata",
                 "type": "object",
+                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
+                "nullable": true
+              },
+              "assets": {
+                "$ref": "#/components/schemas/VoucherAssets"
+              },
+              "is_referral_code": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-22T10:13:06.487Z",
+                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
+                "format": "date-time",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2021-12-22T10:14:45.316Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
+                "nullable": true
+              },
+              "holder_id": {
+                "type": "string",
+                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
+                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
+                "nullable": true
+              },
+              "referrer_id": {
+                "type": "string",
+                "description": "Unique identifier of the referring person.",
+                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "description": "The type of the object represented by JSON. Default is `voucher`.",
+                "default": "voucher",
+                "nullable": true
+              },
+              "publish": {
+                "title": "RedemptionRedeemVoucherPublish",
+                "type": "object",
+                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
                 "properties": {
-                  "redemptions": {
-                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
                     "nullable": true
                   },
-                  "orders": {
-                    "title": "RedemptionEntryPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
+                  "count": {
+                    "type": "integer",
+                    "example": 0,
+                    "description": "Publication events counter.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
+                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
                     "nullable": true
                   }
                 },
                 "nullable": true
               },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
+              "redemption": {
+                "title": "RedemptionRedeemVoucherRedemption",
+                "type": "object",
+                "description": "Stores a summary of redemptions that have been applied to the voucher.",
+                "properties": {
+                  "quantity": {
+                    "type": "integer",
+                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
+                    "nullable": true
+                  },
+                  "redeemed_quantity": {
+                    "type": "integer",
+                    "example": 1,
+                    "description": "How many times a voucher has already been redeemed.",
+                    "nullable": true
+                  },
+                  "redeemed_points": {
+                    "type": "integer",
+                    "example": 100000,
+                    "description": "Total loyalty points redeemed.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
+                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "categories": {
-                "title": "RedemptionEntryPromotionTierCategories",
+                "title": "RedemptionRedeemVoucherCategories",
                 "type": "array",
+                "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "$ref": "#/components/schemas/CategoryStackingRulesType"
                 },
                 "nullable": true
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              },
+              "holder": {
+                "$ref": "#/components/schemas/SimpleCustomer"
               }
             },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionEntryGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionEntryLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-              }
-            },
-            "nullable": true
-          },
-          "reason": {
-            "type": "string",
-            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
             "nullable": true
           }
-        }
+        },
+        "description": "This is an object representing a redemption for **POST** `v1/redemptions`, **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption`, **POST** `v1/loyalties/members/{memberId}/redemption`, **POST** `/client/v1/redemptions`."
       },
       "RedemptionRewardResult": {
         "title": "RedemptionRewardResult",

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -36594,7 +36594,7 @@
                 "type": "array",
                 "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                  "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                 },
                 "nullable": true
               },

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -37862,7 +37862,7 @@
                 "type": "array",
                 "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                  "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                 },
                 "nullable": true
               },

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -2706,12 +2706,12 @@
             "title": "ClientRedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -9782,6 +9782,38 @@
             "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
             "nullable": true
           },
+          "promotion_tier": {
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucher",
             "description": "Defines the details of the voucher being redeemed.",
@@ -9918,7 +9950,7 @@
                 "type": "array",
                 "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
                 "items": {
-                  "title": "RedemptionVoucherValidityDayOfWeekItem",
+                  "title": "MembersRedemptionVoucherValidityDayOfWeekItem",
                   "type": "integer",
                   "enum": [
                     0,
@@ -10057,9 +10089,9 @@
               "categories": {
                 "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucherCategories",
                 "type": "array",
-                "description": "Contains details about the category.",
+                "description": "Always returns an empty array.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "title": "MembersRedemptionVoucherCategoriesItem"
                 },
                 "nullable": true
               },
@@ -10068,38 +10100,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
               }
             },
             "nullable": true
@@ -22190,6 +22190,271 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionsGetResponseBodyPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionsGetResponseBodyPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierCampaignValidityDayOfWeek",
+                    "type": "array",
+                    "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
+                    "items": {
+                      "title": "RedemptionsGetResponseBodyPromotionTierCampaignValidityDayOfWeekItem",
+                      "type": "integer",
+                      "enum": [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6
+                      ]
+                    },
+                    "nullable": true
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "title": "RedemptionsGetResponseBodyPromotionTierValidityDayOfWeek",
+                "type": "array",
+                "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
+                "items": {
+                  "title": "RedemptionsGetResponseBodyPromotionTierValidityDayOfWeekItem",
+                  "type": "integer",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                  ]
+                },
+                "nullable": true
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionsGetResponseBodyGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionsGetResponseBodyLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionsGetResponseBodyVoucher",
             "type": "object",
@@ -22470,271 +22735,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "title": "RedemptionsGetResponseBodyPromotionTier",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
-                "nullable": true
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionsGetResponseBodyPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
-                "nullable": true
-              },
-              "campaign": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierCampaignValidityDayOfWeek",
-                    "type": "array",
-                    "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
-                    "items": {
-                      "title": "RedemptionsGetResponseBodyPromotionTierCampaignValidityDayOfWeekItem",
-                      "type": "integer",
-                      "enum": [
-                        0,
-                        1,
-                        2,
-                        3,
-                        4,
-                        5,
-                        6
-                      ]
-                    },
-                    "nullable": true
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
-                "nullable": true
-              },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "title": "RedemptionsGetResponseBodyPromotionTierValidityDayOfWeek",
-                "type": "array",
-                "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
-                "items": {
-                  "title": "RedemptionsGetResponseBodyPromotionTierValidityDayOfWeekItem",
-                  "type": "integer",
-                  "enum": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6
-                  ]
-                },
-                "nullable": true
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "summary": {
-                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
-                "type": "object",
-                "properties": {
-                  "redemptions": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  },
-                  "orders": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionsGetResponseBodyGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionsGetResponseBodyLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
               }
             },
             "nullable": true
@@ -23121,6 +23121,260 @@
                 "related_object_id": {
                   "type": "string"
                 },
+                "promotion_tier": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                      "description": "Unique promotion tier ID.",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "example": "2021-12-15T11:34:01.333Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2022-02-09T09:20:05.603Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the promotion tier.",
+                      "nullable": true
+                    },
+                    "banner": {
+                      "type": "string",
+                      "description": "Text to be displayed to your customers on your website.",
+                      "nullable": true
+                    },
+                    "action": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
+                      "type": "object",
+                      "properties": {
+                        "discount": {
+                          "$ref": "#/components/schemas/Discount"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
+                      "type": "object"
+                    },
+                    "hierarchy": {
+                      "type": "integer",
+                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                      "nullable": true
+                    },
+                    "promotion_id": {
+                      "type": "string",
+                      "description": "Promotion unique ID.",
+                      "nullable": true
+                    },
+                    "campaign": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique campaign ID.",
+                          "nullable": true
+                        },
+                        "start_date": {
+                          "type": "string",
+                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                          "format": "date-time",
+                          "example": "2022-09-22T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "expiration_date": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                          "example": "2022-09-30T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "validity_timeframe": {
+                          "$ref": "#/components/schemas/ValidityTimeframe"
+                        },
+                        "validity_day_of_week": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaignValidityDayOfWeek",
+                          "type": "array",
+                          "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
+                          "items": {
+                            "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaignValidityDayOfWeekItem",
+                            "type": "integer",
+                            "enum": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6
+                            ]
+                          },
+                          "nullable": true
+                        },
+                        "validity_hours": {
+                          "$ref": "#/components/schemas/ValidityHours"
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                          "nullable": true
+                        },
+                        "category_id": {
+                          "type": "string",
+                          "example": "cat_0b688929a2476386a6",
+                          "description": "Unique category ID that this campaign belongs to.",
+                          "nullable": true
+                        },
+                        "object": {
+                          "type": "string",
+                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                          "default": "campaign",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "campaign_id": {
+                      "type": "string",
+                      "description": "Promotion tier's parent campaign's unique ID.",
+                      "nullable": true
+                    },
+                    "active": {
+                      "type": "boolean",
+                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                      "nullable": true
+                    },
+                    "start_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-23T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "expiration_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-26T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "validity_timeframe": {
+                      "$ref": "#/components/schemas/ValidityTimeframe"
+                    },
+                    "validity_day_of_week": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierValidityDayOfWeek",
+                      "type": "array",
+                      "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
+                      "items": {
+                        "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierValidityDayOfWeekItem",
+                        "type": "integer",
+                        "enum": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6
+                        ]
+                      },
+                      "nullable": true
+                    },
+                    "validity_hours": {
+                      "$ref": "#/components/schemas/ValidityHours"
+                    },
+                    "summary": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
+                      "type": "object",
+                      "properties": {
+                        "redemptions": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
+                          "type": "object",
+                          "properties": {
+                            "total_redeemed": {
+                              "type": "integer",
+                              "description": "Number of times the promotion tier was redeemed.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "orders": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
+                          "type": "object",
+                          "properties": {
+                            "total_amount": {
+                              "type": "integer",
+                              "description": "Sum of order totals.",
+                              "nullable": true
+                            },
+                            "total_discount_amount": {
+                              "type": "integer",
+                              "description": "Sum of total discount applied using the promotion tier.",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object": {
+                      "type": "string",
+                      "default": "promotion_tier",
+                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                      "nullable": true
+                    },
+                    "validation_rule_assignments": {
+                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+                    },
+                    "category_id": {
+                      "type": "string",
+                      "description": "Promotion tier category ID.",
+                      "example": "cat_0c9da30e7116ba6bba",
+                      "nullable": true
+                    },
+                    "categories": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Category"
+                      },
+                      "nullable": true
+                    }
+                  }
+                },
+                "reward": {
+                  "$ref": "#/components/schemas/RedemptionRewardResult"
+                },
+                "gift": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "integer",
+                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+                    }
+                  }
+                },
+                "loyalty_card": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
+                  "type": "object",
+                  "properties": {
+                    "points": {
+                      "type": "integer",
+                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+                    }
+                  }
+                },
                 "voucher": {
                   "title": "RedemptionsListResponseBodyRedemptionsItemVoucher",
                   "type": "object",
@@ -23399,260 +23653,6 @@
                     }
                   }
                 },
-                "promotion_tier": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                      "description": "Unique promotion tier ID.",
-                      "nullable": true
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "example": "2021-12-15T11:34:01.333Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "example": "2022-02-09T09:20:05.603Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Name of the promotion tier.",
-                      "nullable": true
-                    },
-                    "banner": {
-                      "type": "string",
-                      "description": "Text to be displayed to your customers on your website.",
-                      "nullable": true
-                    },
-                    "action": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
-                      "type": "object",
-                      "properties": {
-                        "discount": {
-                          "$ref": "#/components/schemas/Discount"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
-                      "type": "object"
-                    },
-                    "hierarchy": {
-                      "type": "integer",
-                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                      "nullable": true
-                    },
-                    "promotion_id": {
-                      "type": "string",
-                      "description": "Promotion unique ID.",
-                      "nullable": true
-                    },
-                    "campaign": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "Unique campaign ID.",
-                          "nullable": true
-                        },
-                        "start_date": {
-                          "type": "string",
-                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                          "format": "date-time",
-                          "example": "2022-09-22T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "expiration_date": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                          "example": "2022-09-30T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "validity_timeframe": {
-                          "$ref": "#/components/schemas/ValidityTimeframe"
-                        },
-                        "validity_day_of_week": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaignValidityDayOfWeek",
-                          "type": "array",
-                          "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
-                          "items": {
-                            "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaignValidityDayOfWeekItem",
-                            "type": "integer",
-                            "enum": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5,
-                              6
-                            ]
-                          },
-                          "nullable": true
-                        },
-                        "validity_hours": {
-                          "$ref": "#/components/schemas/ValidityHours"
-                        },
-                        "active": {
-                          "type": "boolean",
-                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                          "nullable": true
-                        },
-                        "category_id": {
-                          "type": "string",
-                          "example": "cat_0b688929a2476386a6",
-                          "description": "Unique category ID that this campaign belongs to.",
-                          "nullable": true
-                        },
-                        "object": {
-                          "type": "string",
-                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                          "default": "campaign",
-                          "nullable": true
-                        }
-                      }
-                    },
-                    "campaign_id": {
-                      "type": "string",
-                      "description": "Promotion tier's parent campaign's unique ID.",
-                      "nullable": true
-                    },
-                    "active": {
-                      "type": "boolean",
-                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                      "nullable": true
-                    },
-                    "start_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-23T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "expiration_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-26T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "validity_timeframe": {
-                      "$ref": "#/components/schemas/ValidityTimeframe"
-                    },
-                    "validity_day_of_week": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierValidityDayOfWeek",
-                      "type": "array",
-                      "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
-                      "items": {
-                        "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierValidityDayOfWeekItem",
-                        "type": "integer",
-                        "enum": [
-                          0,
-                          1,
-                          2,
-                          3,
-                          4,
-                          5,
-                          6
-                        ]
-                      },
-                      "nullable": true
-                    },
-                    "validity_hours": {
-                      "$ref": "#/components/schemas/ValidityHours"
-                    },
-                    "summary": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
-                      "type": "object",
-                      "properties": {
-                        "redemptions": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
-                          "type": "object",
-                          "properties": {
-                            "total_redeemed": {
-                              "type": "integer",
-                              "description": "Number of times the promotion tier was redeemed.",
-                              "nullable": true
-                            }
-                          }
-                        },
-                        "orders": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
-                          "type": "object",
-                          "properties": {
-                            "total_amount": {
-                              "type": "integer",
-                              "description": "Sum of order totals.",
-                              "nullable": true
-                            },
-                            "total_discount_amount": {
-                              "type": "integer",
-                              "description": "Sum of total discount applied using the promotion tier.",
-                              "nullable": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "object": {
-                      "type": "string",
-                      "default": "promotion_tier",
-                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                      "nullable": true
-                    },
-                    "validation_rule_assignments": {
-                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-                    },
-                    "category_id": {
-                      "type": "string",
-                      "description": "Promotion tier category ID.",
-                      "example": "cat_0c9da30e7116ba6bba",
-                      "nullable": true
-                    },
-                    "categories": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Category"
-                      },
-                      "nullable": true
-                    }
-                  }
-                },
-                "reward": {
-                  "$ref": "#/components/schemas/RedemptionRewardResult"
-                },
-                "gift": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "integer",
-                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-                    }
-                  }
-                },
-                "loyalty_card": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
-                  "type": "object",
-                  "properties": {
-                    "points": {
-                      "type": "integer",
-                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-                    }
-                  }
-                },
                 "reason": {
                   "type": "string",
                   "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
@@ -23784,12 +23784,12 @@
             "title": "RedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -36445,512 +36445,6 @@
         },
         "required": []
       },
-      "Redemption": {
-        "title": "Redemption",
-        "type": "object",
-        "description": "This is an object representing a redemption.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "r_0bc92f81a6801f9bca",
-            "description": "Unique redemption ID.",
-            "nullable": true
-          },
-          "object": {
-            "type": "string",
-            "description": "The type of the object represented by the JSON",
-            "default": "redemption",
-            "enum": [
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "date": {
-            "type": "string",
-            "example": "2021-12-22T10:13:06.487Z",
-            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "customer_id": {
-            "type": "string",
-            "nullable": true,
-            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
-            "description": "Unique customer ID of the redeeming customer."
-          },
-          "tracking_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "Hashed customer source ID."
-          },
-          "metadata": {
-            "title": "RedemptionMetadata",
-            "type": "object",
-            "nullable": true,
-            "description": "The metadata object stores all custom attributes assigned to the redemption."
-          },
-          "amount": {
-            "type": "integer",
-            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
-            "example": 10000,
-            "nullable": true
-          },
-          "redemption": {
-            "nullable": true,
-            "type": "string",
-            "description": "Unique redemption ID of the parent redemption.",
-            "example": "r_0c656311b5878a2031"
-          },
-          "result": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILURE"
-            ],
-            "description": "Redemption result.",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "SUCCEEDED",
-              "FAILED",
-              "ROLLED_BACK"
-            ],
-            "description": "Redemption status.",
-            "nullable": true
-          },
-          "related_redemptions": {
-            "title": "RedemptionRelatedRedemptions",
-            "type": "object",
-            "properties": {
-              "rollbacks": {
-                "title": "RedemptionRelatedRedemptionsRollbacks",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRollbacksItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "rr_0bc92f81a6801f9bca",
-                      "description": "Unique rollback redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              },
-              "redemptions": {
-                "title": "RedemptionRelatedRedemptionsRedemptions",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRedemptionsItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "r_0bc92f81a6801f9bca",
-                      "description": "Unique redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "failure_code": {
-            "type": "string",
-            "example": "customer_rules_violated",
-            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "failure_message": {
-            "type": "string",
-            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "order": {
-            "$ref": "#/components/schemas/OrderCalculated"
-          },
-          "channel": {
-            "title": "RedemptionChannel",
-            "type": "object",
-            "description": "Defines the details of the channel through which the redemption was issued.",
-            "properties": {
-              "channel_id": {
-                "type": "string",
-                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
-                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
-                "nullable": true
-              },
-              "channel_type": {
-                "type": "string",
-                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
-                "enum": [
-                  "USER",
-                  "API"
-                ],
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "customer": {
-            "$ref": "#/components/schemas/SimpleCustomer"
-          },
-          "related_object_type": {
-            "type": "string",
-            "description": "Defines the related object.",
-            "enum": [
-              "voucher",
-              "promotion_tier",
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "related_object_id": {
-            "type": "string",
-            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
-            "nullable": true
-          },
-          "voucher": {
-            "title": "RedemptionVoucher",
-            "description": "Defines the details of the voucher being redeemed.",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
-                "description": "Assigned by the Voucherify API, identifies the voucher.",
-                "nullable": true
-              },
-              "code": {
-                "type": "string",
-                "example": "WVPblOYX",
-                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
-                "nullable": true
-              },
-              "campaign": {
-                "type": "string",
-                "example": "Gift Card Campaign",
-                "description": "A unique campaign name, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
-                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "category": {
-                "type": "string",
-                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
-                "nullable": true
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Unique category ID assigned by Voucherify.",
-                "example": "cat_0bb343dee3cdb5ec0c",
-                "nullable": true
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "GIFT_VOUCHER",
-                  "DISCOUNT_VOUCHER",
-                  "LOYALTY_CARD"
-                ],
-                "description": "Defines the type of the voucher. ",
-                "nullable": true
-              },
-              "discount": {
-                "$ref": "#/components/schemas/Discount"
-              },
-              "gift": {
-                "title": "RedemptionVoucherGift",
-                "type": "object",
-                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
-                "properties": {
-                  "amount": {
-                    "type": "integer",
-                    "example": 10000,
-                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 500,
-                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "effect": {
-                    "type": "string",
-                    "enum": [
-                      "APPLY_TO_ORDER",
-                      "APPLY_TO_ITEMS"
-                    ],
-                    "description": "Defines how the credits are applied to the customer's order.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "loyalty_card": {
-                "title": "RedemptionVoucherLoyaltyCard",
-                "type": "object",
-                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
-                "properties": {
-                  "points": {
-                    "type": "integer",
-                    "example": 7000,
-                    "description": "Total points incurred over the lifespan of the loyalty card.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 6970,
-                    "description": "Points available for reward redemption.",
-                    "nullable": true
-                  },
-                  "next_expiration_date": {
-                    "type": "string",
-                    "format": "date",
-                    "example": "2023-05-30",
-                    "description": "The next closest date when the next set of points are due to expire.",
-                    "nullable": true
-                  },
-                  "next_expiration_points": {
-                    "type": "integer",
-                    "description": "The amount of points that are set to expire next.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "example": "2021-12-01T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "example": "2021-12-31T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "title": "RedemptionVoucherValidityDayOfWeek",
-                "type": "array",
-                "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
-                "items": {
-                  "title": "VoucherValidityDayOfWeekItem",
-                  "type": "integer",
-                  "enum": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6
-                  ]
-                },
-                "nullable": true
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "active": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
-              },
-              "additional_info": {
-                "type": "string",
-                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionVoucherMetadata",
-                "type": "object",
-                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
-                "nullable": true
-              },
-              "assets": {
-                "$ref": "#/components/schemas/VoucherAssets"
-              },
-              "is_referral_code": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-22T10:13:06.487Z",
-                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
-                "format": "date-time",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2021-12-22T10:14:45.316Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
-                "nullable": true
-              },
-              "holder_id": {
-                "type": "string",
-                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
-                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
-                "nullable": true
-              },
-              "referrer_id": {
-                "type": "string",
-                "description": "Unique identifier of the referring person.",
-                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "description": "The type of the object represented by JSON. Default is `voucher`.",
-                "default": "voucher",
-                "nullable": true
-              },
-              "publish": {
-                "title": "RedemptionVoucherPublish",
-                "type": "object",
-                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
-                "properties": {
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
-                    "nullable": true
-                  },
-                  "count": {
-                    "type": "integer",
-                    "example": 0,
-                    "description": "Publication events counter.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
-                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "redemption": {
-                "title": "RedemptionVoucherRedemption",
-                "type": "object",
-                "description": "Stores a summary of redemptions that have been applied to the voucher.",
-                "properties": {
-                  "quantity": {
-                    "type": "integer",
-                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
-                    "nullable": true
-                  },
-                  "redeemed_quantity": {
-                    "type": "integer",
-                    "example": 1,
-                    "description": "How many times a voucher has already been redeemed.",
-                    "nullable": true
-                  },
-                  "redeemed_points": {
-                    "type": "integer",
-                    "example": 100000,
-                    "description": "Total loyalty points redeemed.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
-                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionVoucherCategories",
-                "type": "array",
-                "description": "Contains details about the category.",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              },
-              "validation_rules_assignments": {
-                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
-              },
-              "holder": {
-                "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          }
-        },
-        "required": []
-      },
       "RedemptionEntry": {
         "title": "RedemptionEntry",
         "type": "object",
@@ -37323,6 +36817,271 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionEntryPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionEntryPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionEntryPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionEntryPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "title": "RedemptionEntryPromotionTierCampaignValidityDayOfWeek",
+                    "type": "array",
+                    "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
+                    "items": {
+                      "title": "RedemptionEntryPromotionTierCampaignValidityDayOfWeekItem",
+                      "type": "integer",
+                      "enum": [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6
+                      ]
+                    },
+                    "nullable": true
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "title": "RedemptionEntryPromotionTierValidityDayOfWeek",
+                "type": "array",
+                "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
+                "items": {
+                  "title": "RedemptionEntryPromotionTierValidityDayOfWeekItem",
+                  "type": "integer",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                  ]
+                },
+                "nullable": true
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionEntryPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionEntryPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionEntryPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionEntryGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionEntryLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionEntryVoucher",
             "type": "object",
@@ -37607,166 +37366,362 @@
             },
             "nullable": true
           },
+          "reason": {
+            "type": "string",
+            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
+            "nullable": true
+          }
+        }
+      },
+      "RedemptionRedeem": {
+        "title": "RedemptionRedeem",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "r_0bc92f81a6801f9bca",
+            "description": "Unique redemption ID.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "description": "The type of the object represented by the JSON",
+            "default": "redemption",
+            "enum": [
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "example": "2021-12-22T10:13:06.487Z",
+            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "customer_id": {
+            "type": "string",
+            "nullable": true,
+            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
+            "description": "Unique customer ID of the redeeming customer."
+          },
+          "tracking_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Hashed customer source ID."
+          },
+          "metadata": {
+            "title": "RedemptionRedeemMetadata",
+            "type": "object",
+            "nullable": true,
+            "description": "The metadata object stores all custom attributes assigned to the redemption."
+          },
+          "amount": {
+            "type": "integer",
+            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
+            "example": 10000,
+            "nullable": true
+          },
+          "redemption": {
+            "nullable": true,
+            "type": "string",
+            "description": "Unique redemption ID of the parent redemption.",
+            "example": "r_0c656311b5878a2031"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILURE"
+            ],
+            "description": "Redemption result.",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUCCEEDED",
+              "FAILED",
+              "ROLLED_BACK"
+            ],
+            "description": "Redemption status.",
+            "nullable": true
+          },
+          "related_redemptions": {
+            "title": "RedemptionRedeemRelatedRedemptions",
+            "type": "object",
+            "properties": {
+              "rollbacks": {
+                "title": "RedemptionRedeemRelatedRedemptionsRollbacks",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRollbacksItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "rr_0bc92f81a6801f9bca",
+                      "description": "Unique rollback redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              },
+              "redemptions": {
+                "title": "RedemptionRedeemRelatedRedemptionsRedemptions",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRedemptionsItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "r_0bc92f81a6801f9bca",
+                      "description": "Unique redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "failure_code": {
+            "type": "string",
+            "example": "customer_rules_violated",
+            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "failure_message": {
+            "type": "string",
+            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "order": {
+            "$ref": "#/components/schemas/OrderCalculated"
+          },
+          "channel": {
+            "title": "RedemptionRedeemChannel",
+            "type": "object",
+            "description": "Defines the details of the channel through which the redemption was issued.",
+            "properties": {
+              "channel_id": {
+                "type": "string",
+                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
+                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
+                "nullable": true
+              },
+              "channel_type": {
+                "type": "string",
+                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
+                "enum": [
+                  "USER",
+                  "API"
+                ],
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "customer": {
+            "$ref": "#/components/schemas/SimpleCustomer"
+          },
+          "related_object_type": {
+            "type": "string",
+            "description": "Defines the related object.",
+            "enum": [
+              "voucher",
+              "promotion_tier",
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "related_object_id": {
+            "type": "string",
+            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
+            "nullable": true
+          },
           "promotion_tier": {
-            "title": "RedemptionEntryPromotionTier",
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionRedeemGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionRedeemLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "voucher": {
+            "title": "RedemptionRedeemVoucher",
+            "description": "Defines the details of the voucher being redeemed.",
             "type": "object",
             "properties": {
               "id": {
                 "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
+                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
+                "description": "Assigned by the Voucherify API, identifies the voucher.",
                 "nullable": true
               },
-              "created_at": {
+              "code": {
                 "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionEntryPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionEntryPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
+                "example": "WVPblOYX",
+                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
                 "nullable": true
               },
               "campaign": {
-                "title": "RedemptionEntryPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "title": "RedemptionEntryPromotionTierCampaignValidityDayOfWeek",
-                    "type": "array",
-                    "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
-                    "items": {
-                      "title": "RedemptionEntryPromotionTierCampaignValidityDayOfWeekItem",
-                      "type": "integer",
-                      "enum": [
-                        0,
-                        1,
-                        2,
-                        3,
-                        4,
-                        5,
-                        6
-                      ]
-                    },
-                    "nullable": true
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
+                "type": "string",
+                "example": "Gift Card Campaign",
+                "description": "A unique campaign name, identifies the voucher's parent campaign.",
                 "nullable": true
               },
               "campaign_id": {
                 "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
+                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
+                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
                 "nullable": true
               },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+              "category": {
+                "type": "string",
+                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
+                "nullable": true
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Unique category ID assigned by Voucherify.",
+                "example": "cat_0bb343dee3cdb5ec0c",
+                "nullable": true
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "GIFT_VOUCHER",
+                  "DISCOUNT_VOUCHER",
+                  "LOYALTY_CARD"
+                ],
+                "description": "Defines the type of the voucher. ",
+                "nullable": true
+              },
+              "discount": {
+                "$ref": "#/components/schemas/Discount"
+              },
+              "gift": {
+                "title": "RedemptionRedeemVoucherGift",
+                "type": "object",
+                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
+                "properties": {
+                  "amount": {
+                    "type": "integer",
+                    "example": 10000,
+                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 500,
+                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "effect": {
+                    "type": "string",
+                    "enum": [
+                      "APPLY_TO_ORDER",
+                      "APPLY_TO_ITEMS"
+                    ],
+                    "description": "Defines how the credits are applied to the customer's order.",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "loyalty_card": {
+                "title": "RedemptionRedeemVoucherLoyaltyCard",
+                "type": "object",
+                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
+                "properties": {
+                  "points": {
+                    "type": "integer",
+                    "example": 7000,
+                    "description": "Total points incurred over the lifespan of the loyalty card.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 6970,
+                    "description": "Points available for reward redemption.",
+                    "nullable": true
+                  },
+                  "next_expiration_date": {
+                    "type": "string",
+                    "format": "date",
+                    "example": "2023-05-30",
+                    "description": "The next closest date when the next set of points are due to expire.",
+                    "nullable": true
+                  },
+                  "next_expiration_points": {
+                    "type": "integer",
+                    "description": "The amount of points that are set to expire next.",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "start_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "example": "2021-12-01T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
+                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
                 "nullable": true
               },
               "expiration_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "example": "2021-12-31T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
+                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
                 "nullable": true
               },
               "validity_timeframe": {
                 "$ref": "#/components/schemas/ValidityTimeframe"
               },
               "validity_day_of_week": {
-                "title": "RedemptionEntryPromotionTierValidityDayOfWeek",
+                "title": "RedemptionRedeemVoucherValidityDayOfWeek",
                 "type": "array",
                 "description": "Integer array corresponding to the particular days of the week in which the voucher is valid.\n\n- `0` Sunday\n- `1` Monday\n- `2` Tuesday\n- `3` Wednesday\n- `4` Thursday\n- `5` Friday\n- `6` Saturday",
                 "items": {
-                  "title": "RedemptionEntryPromotionTierValidityDayOfWeekItem",
+                  "title": "VoucherQualificationValidationRedemptionValidityDayOfWeekItem",
                   "type": "integer",
                   "enum": [
                     0,
@@ -37783,101 +37738,145 @@
               "validity_hours": {
                 "$ref": "#/components/schemas/ValidityHours"
               },
-              "summary": {
-                "title": "RedemptionEntryPromotionTierSummary",
+              "active": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
+              },
+              "additional_info": {
+                "type": "string",
+                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionRedeemVoucherMetadata",
                 "type": "object",
+                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
+                "nullable": true
+              },
+              "assets": {
+                "$ref": "#/components/schemas/VoucherAssets"
+              },
+              "is_referral_code": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-22T10:13:06.487Z",
+                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
+                "format": "date-time",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2021-12-22T10:14:45.316Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
+                "nullable": true
+              },
+              "holder_id": {
+                "type": "string",
+                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
+                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
+                "nullable": true
+              },
+              "referrer_id": {
+                "type": "string",
+                "description": "Unique identifier of the referring person.",
+                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "description": "The type of the object represented by JSON. Default is `voucher`.",
+                "default": "voucher",
+                "nullable": true
+              },
+              "publish": {
+                "title": "RedemptionRedeemVoucherPublish",
+                "type": "object",
+                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
                 "properties": {
-                  "redemptions": {
-                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
                     "nullable": true
                   },
-                  "orders": {
-                    "title": "RedemptionEntryPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
+                  "count": {
+                    "type": "integer",
+                    "example": 0,
+                    "description": "Publication events counter.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
+                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
                     "nullable": true
                   }
                 },
                 "nullable": true
               },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
+              "redemption": {
+                "title": "RedemptionRedeemVoucherRedemption",
+                "type": "object",
+                "description": "Stores a summary of redemptions that have been applied to the voucher.",
+                "properties": {
+                  "quantity": {
+                    "type": "integer",
+                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
+                    "nullable": true
+                  },
+                  "redeemed_quantity": {
+                    "type": "integer",
+                    "example": 1,
+                    "description": "How many times a voucher has already been redeemed.",
+                    "nullable": true
+                  },
+                  "redeemed_points": {
+                    "type": "integer",
+                    "example": 100000,
+                    "description": "Total loyalty points redeemed.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
+                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "categories": {
-                "title": "RedemptionEntryPromotionTierCategories",
+                "title": "RedemptionRedeemVoucherCategories",
                 "type": "array",
+                "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "$ref": "#/components/schemas/CategoryStackingRulesType"
                 },
                 "nullable": true
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              },
+              "holder": {
+                "$ref": "#/components/schemas/SimpleCustomer"
               }
             },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionEntryGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionEntryLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-              }
-            },
-            "nullable": true
-          },
-          "reason": {
-            "type": "string",
-            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
             "nullable": true
           }
-        }
+        },
+        "description": "This is an object representing a redemption for **POST** `v1/redemptions`, **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption`, **POST** `v1/loyalties/members/{memberId}/redemption`, **POST** `/client/v1/redemptions`."
       },
       "RedemptionRewardResult": {
         "title": "RedemptionRewardResult",

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -2594,12 +2594,12 @@
             "title": "ClientRedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -9408,6 +9408,38 @@
             "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
             "nullable": true
           },
+          "promotion_tier": {
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucher",
             "description": "Defines the details of the voucher being redeemed.",
@@ -9667,9 +9699,9 @@
               "categories": {
                 "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucherCategories",
                 "type": "array",
-                "description": "Contains details about the category.",
+                "description": "Always returns an empty array.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "title": "MembersRedemptionVoucherCategoriesItem"
                 },
                 "nullable": true
               },
@@ -9678,38 +9710,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
               }
             },
             "nullable": true
@@ -21235,6 +21235,239 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionsGetResponseBodyPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionsGetResponseBodyPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "$ref": "#/components/schemas/ValidityDayOfWeek"
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "$ref": "#/components/schemas/ValidityDayOfWeek"
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionsGetResponseBodyGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionsGetResponseBodyLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionsGetResponseBodyVoucher",
             "type": "object",
@@ -21499,239 +21732,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "title": "RedemptionsGetResponseBodyPromotionTier",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
-                "nullable": true
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionsGetResponseBodyPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
-                "nullable": true
-              },
-              "campaign": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "$ref": "#/components/schemas/ValidityDayOfWeek"
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
-                "nullable": true
-              },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "$ref": "#/components/schemas/ValidityDayOfWeek"
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "summary": {
-                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
-                "type": "object",
-                "properties": {
-                  "redemptions": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  },
-                  "orders": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionsGetResponseBodyGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionsGetResponseBodyLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
               }
             },
             "nullable": true
@@ -22118,6 +22118,228 @@
                 "related_object_id": {
                   "type": "string"
                 },
+                "promotion_tier": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                      "description": "Unique promotion tier ID.",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "example": "2021-12-15T11:34:01.333Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2022-02-09T09:20:05.603Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the promotion tier.",
+                      "nullable": true
+                    },
+                    "banner": {
+                      "type": "string",
+                      "description": "Text to be displayed to your customers on your website.",
+                      "nullable": true
+                    },
+                    "action": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
+                      "type": "object",
+                      "properties": {
+                        "discount": {
+                          "$ref": "#/components/schemas/Discount"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
+                      "type": "object"
+                    },
+                    "hierarchy": {
+                      "type": "integer",
+                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                      "nullable": true
+                    },
+                    "promotion_id": {
+                      "type": "string",
+                      "description": "Promotion unique ID.",
+                      "nullable": true
+                    },
+                    "campaign": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique campaign ID.",
+                          "nullable": true
+                        },
+                        "start_date": {
+                          "type": "string",
+                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                          "format": "date-time",
+                          "example": "2022-09-22T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "expiration_date": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                          "example": "2022-09-30T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "validity_timeframe": {
+                          "$ref": "#/components/schemas/ValidityTimeframe"
+                        },
+                        "validity_day_of_week": {
+                          "$ref": "#/components/schemas/ValidityDayOfWeek"
+                        },
+                        "validity_hours": {
+                          "$ref": "#/components/schemas/ValidityHours"
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                          "nullable": true
+                        },
+                        "category_id": {
+                          "type": "string",
+                          "example": "cat_0b688929a2476386a6",
+                          "description": "Unique category ID that this campaign belongs to.",
+                          "nullable": true
+                        },
+                        "object": {
+                          "type": "string",
+                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                          "default": "campaign",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "campaign_id": {
+                      "type": "string",
+                      "description": "Promotion tier's parent campaign's unique ID.",
+                      "nullable": true
+                    },
+                    "active": {
+                      "type": "boolean",
+                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                      "nullable": true
+                    },
+                    "start_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-23T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "expiration_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-26T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "validity_timeframe": {
+                      "$ref": "#/components/schemas/ValidityTimeframe"
+                    },
+                    "validity_day_of_week": {
+                      "$ref": "#/components/schemas/ValidityDayOfWeek"
+                    },
+                    "validity_hours": {
+                      "$ref": "#/components/schemas/ValidityHours"
+                    },
+                    "summary": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
+                      "type": "object",
+                      "properties": {
+                        "redemptions": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
+                          "type": "object",
+                          "properties": {
+                            "total_redeemed": {
+                              "type": "integer",
+                              "description": "Number of times the promotion tier was redeemed.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "orders": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
+                          "type": "object",
+                          "properties": {
+                            "total_amount": {
+                              "type": "integer",
+                              "description": "Sum of order totals.",
+                              "nullable": true
+                            },
+                            "total_discount_amount": {
+                              "type": "integer",
+                              "description": "Sum of total discount applied using the promotion tier.",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object": {
+                      "type": "string",
+                      "default": "promotion_tier",
+                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                      "nullable": true
+                    },
+                    "validation_rule_assignments": {
+                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+                    },
+                    "category_id": {
+                      "type": "string",
+                      "description": "Promotion tier category ID.",
+                      "example": "cat_0c9da30e7116ba6bba",
+                      "nullable": true
+                    },
+                    "categories": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Category"
+                      },
+                      "nullable": true
+                    }
+                  }
+                },
+                "reward": {
+                  "$ref": "#/components/schemas/RedemptionRewardResult"
+                },
+                "gift": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "integer",
+                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+                    }
+                  }
+                },
+                "loyalty_card": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
+                  "type": "object",
+                  "properties": {
+                    "points": {
+                      "type": "integer",
+                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+                    }
+                  }
+                },
                 "voucher": {
                   "title": "RedemptionsListResponseBodyRedemptionsItemVoucher",
                   "type": "object",
@@ -22380,228 +22602,6 @@
                     }
                   }
                 },
-                "promotion_tier": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                      "description": "Unique promotion tier ID.",
-                      "nullable": true
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "example": "2021-12-15T11:34:01.333Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "example": "2022-02-09T09:20:05.603Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Name of the promotion tier.",
-                      "nullable": true
-                    },
-                    "banner": {
-                      "type": "string",
-                      "description": "Text to be displayed to your customers on your website.",
-                      "nullable": true
-                    },
-                    "action": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
-                      "type": "object",
-                      "properties": {
-                        "discount": {
-                          "$ref": "#/components/schemas/Discount"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
-                      "type": "object"
-                    },
-                    "hierarchy": {
-                      "type": "integer",
-                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                      "nullable": true
-                    },
-                    "promotion_id": {
-                      "type": "string",
-                      "description": "Promotion unique ID.",
-                      "nullable": true
-                    },
-                    "campaign": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "Unique campaign ID.",
-                          "nullable": true
-                        },
-                        "start_date": {
-                          "type": "string",
-                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                          "format": "date-time",
-                          "example": "2022-09-22T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "expiration_date": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                          "example": "2022-09-30T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "validity_timeframe": {
-                          "$ref": "#/components/schemas/ValidityTimeframe"
-                        },
-                        "validity_day_of_week": {
-                          "$ref": "#/components/schemas/ValidityDayOfWeek"
-                        },
-                        "validity_hours": {
-                          "$ref": "#/components/schemas/ValidityHours"
-                        },
-                        "active": {
-                          "type": "boolean",
-                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                          "nullable": true
-                        },
-                        "category_id": {
-                          "type": "string",
-                          "example": "cat_0b688929a2476386a6",
-                          "description": "Unique category ID that this campaign belongs to.",
-                          "nullable": true
-                        },
-                        "object": {
-                          "type": "string",
-                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                          "default": "campaign",
-                          "nullable": true
-                        }
-                      }
-                    },
-                    "campaign_id": {
-                      "type": "string",
-                      "description": "Promotion tier's parent campaign's unique ID.",
-                      "nullable": true
-                    },
-                    "active": {
-                      "type": "boolean",
-                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                      "nullable": true
-                    },
-                    "start_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-23T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "expiration_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-26T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "validity_timeframe": {
-                      "$ref": "#/components/schemas/ValidityTimeframe"
-                    },
-                    "validity_day_of_week": {
-                      "$ref": "#/components/schemas/ValidityDayOfWeek"
-                    },
-                    "validity_hours": {
-                      "$ref": "#/components/schemas/ValidityHours"
-                    },
-                    "summary": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
-                      "type": "object",
-                      "properties": {
-                        "redemptions": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
-                          "type": "object",
-                          "properties": {
-                            "total_redeemed": {
-                              "type": "integer",
-                              "description": "Number of times the promotion tier was redeemed.",
-                              "nullable": true
-                            }
-                          }
-                        },
-                        "orders": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
-                          "type": "object",
-                          "properties": {
-                            "total_amount": {
-                              "type": "integer",
-                              "description": "Sum of order totals.",
-                              "nullable": true
-                            },
-                            "total_discount_amount": {
-                              "type": "integer",
-                              "description": "Sum of total discount applied using the promotion tier.",
-                              "nullable": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "object": {
-                      "type": "string",
-                      "default": "promotion_tier",
-                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                      "nullable": true
-                    },
-                    "validation_rule_assignments": {
-                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-                    },
-                    "category_id": {
-                      "type": "string",
-                      "description": "Promotion tier category ID.",
-                      "example": "cat_0c9da30e7116ba6bba",
-                      "nullable": true
-                    },
-                    "categories": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Category"
-                      },
-                      "nullable": true
-                    }
-                  }
-                },
-                "reward": {
-                  "$ref": "#/components/schemas/RedemptionRewardResult"
-                },
-                "gift": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "integer",
-                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-                    }
-                  }
-                },
-                "loyalty_card": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
-                  "type": "object",
-                  "properties": {
-                    "points": {
-                      "type": "integer",
-                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-                    }
-                  }
-                },
                 "reason": {
                   "type": "string",
                   "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
@@ -22733,12 +22733,12 @@
             "title": "RedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -34699,496 +34699,6 @@
         },
         "required": []
       },
-      "Redemption": {
-        "title": "Redemption",
-        "type": "object",
-        "description": "This is an object representing a redemption.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "r_0bc92f81a6801f9bca",
-            "description": "Unique redemption ID.",
-            "nullable": true
-          },
-          "object": {
-            "type": "string",
-            "description": "The type of the object represented by the JSON",
-            "default": "redemption",
-            "enum": [
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "date": {
-            "type": "string",
-            "example": "2021-12-22T10:13:06.487Z",
-            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "customer_id": {
-            "type": "string",
-            "nullable": true,
-            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
-            "description": "Unique customer ID of the redeeming customer."
-          },
-          "tracking_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "Hashed customer source ID."
-          },
-          "metadata": {
-            "title": "RedemptionMetadata",
-            "type": "object",
-            "nullable": true,
-            "description": "The metadata object stores all custom attributes assigned to the redemption."
-          },
-          "amount": {
-            "type": "integer",
-            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
-            "example": 10000,
-            "nullable": true
-          },
-          "redemption": {
-            "nullable": true,
-            "type": "string",
-            "description": "Unique redemption ID of the parent redemption.",
-            "example": "r_0c656311b5878a2031"
-          },
-          "result": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILURE"
-            ],
-            "description": "Redemption result.",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "SUCCEEDED",
-              "FAILED",
-              "ROLLED_BACK"
-            ],
-            "description": "Redemption status.",
-            "nullable": true
-          },
-          "related_redemptions": {
-            "title": "RedemptionRelatedRedemptions",
-            "type": "object",
-            "properties": {
-              "rollbacks": {
-                "title": "RedemptionRelatedRedemptionsRollbacks",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRollbacksItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "rr_0bc92f81a6801f9bca",
-                      "description": "Unique rollback redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              },
-              "redemptions": {
-                "title": "RedemptionRelatedRedemptionsRedemptions",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRedemptionsItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "r_0bc92f81a6801f9bca",
-                      "description": "Unique redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "failure_code": {
-            "type": "string",
-            "example": "customer_rules_violated",
-            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "failure_message": {
-            "type": "string",
-            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "order": {
-            "$ref": "#/components/schemas/OrderCalculated"
-          },
-          "channel": {
-            "title": "RedemptionChannel",
-            "type": "object",
-            "description": "Defines the details of the channel through which the redemption was issued.",
-            "properties": {
-              "channel_id": {
-                "type": "string",
-                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
-                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
-                "nullable": true
-              },
-              "channel_type": {
-                "type": "string",
-                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
-                "enum": [
-                  "USER",
-                  "API"
-                ],
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "customer": {
-            "$ref": "#/components/schemas/SimpleCustomer"
-          },
-          "related_object_type": {
-            "type": "string",
-            "description": "Defines the related object.",
-            "enum": [
-              "voucher",
-              "promotion_tier",
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "related_object_id": {
-            "type": "string",
-            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
-            "nullable": true
-          },
-          "voucher": {
-            "title": "RedemptionVoucher",
-            "description": "Defines the details of the voucher being redeemed.",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
-                "description": "Assigned by the Voucherify API, identifies the voucher.",
-                "nullable": true
-              },
-              "code": {
-                "type": "string",
-                "example": "WVPblOYX",
-                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
-                "nullable": true
-              },
-              "campaign": {
-                "type": "string",
-                "example": "Gift Card Campaign",
-                "description": "A unique campaign name, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
-                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "category": {
-                "type": "string",
-                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
-                "nullable": true
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Unique category ID assigned by Voucherify.",
-                "example": "cat_0bb343dee3cdb5ec0c",
-                "nullable": true
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "GIFT_VOUCHER",
-                  "DISCOUNT_VOUCHER",
-                  "LOYALTY_CARD"
-                ],
-                "description": "Defines the type of the voucher. ",
-                "nullable": true
-              },
-              "discount": {
-                "$ref": "#/components/schemas/Discount"
-              },
-              "gift": {
-                "title": "RedemptionVoucherGift",
-                "type": "object",
-                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
-                "properties": {
-                  "amount": {
-                    "type": "integer",
-                    "example": 10000,
-                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 500,
-                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "effect": {
-                    "type": "string",
-                    "enum": [
-                      "APPLY_TO_ORDER",
-                      "APPLY_TO_ITEMS"
-                    ],
-                    "description": "Defines how the credits are applied to the customer's order.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "loyalty_card": {
-                "title": "RedemptionVoucherLoyaltyCard",
-                "type": "object",
-                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
-                "properties": {
-                  "points": {
-                    "type": "integer",
-                    "example": 7000,
-                    "description": "Total points incurred over the lifespan of the loyalty card.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 6970,
-                    "description": "Points available for reward redemption.",
-                    "nullable": true
-                  },
-                  "next_expiration_date": {
-                    "type": "string",
-                    "format": "date",
-                    "example": "2023-05-30",
-                    "description": "The next closest date when the next set of points are due to expire.",
-                    "nullable": true
-                  },
-                  "next_expiration_points": {
-                    "type": "integer",
-                    "description": "The amount of points that are set to expire next.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "example": "2021-12-01T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "example": "2021-12-31T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "$ref": "#/components/schemas/ValidityDayOfWeek"
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "active": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
-              },
-              "additional_info": {
-                "type": "string",
-                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionVoucherMetadata",
-                "type": "object",
-                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
-                "nullable": true
-              },
-              "assets": {
-                "$ref": "#/components/schemas/VoucherAssets"
-              },
-              "is_referral_code": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-22T10:13:06.487Z",
-                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
-                "format": "date-time",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2021-12-22T10:14:45.316Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
-                "nullable": true
-              },
-              "holder_id": {
-                "type": "string",
-                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
-                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
-                "nullable": true
-              },
-              "referrer_id": {
-                "type": "string",
-                "description": "Unique identifier of the referring person.",
-                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "description": "The type of the object represented by JSON. Default is `voucher`.",
-                "default": "voucher",
-                "nullable": true
-              },
-              "publish": {
-                "title": "RedemptionVoucherPublish",
-                "type": "object",
-                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
-                "properties": {
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
-                    "nullable": true
-                  },
-                  "count": {
-                    "type": "integer",
-                    "example": 0,
-                    "description": "Publication events counter.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
-                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "redemption": {
-                "title": "RedemptionVoucherRedemption",
-                "type": "object",
-                "description": "Stores a summary of redemptions that have been applied to the voucher.",
-                "properties": {
-                  "quantity": {
-                    "type": "integer",
-                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
-                    "nullable": true
-                  },
-                  "redeemed_quantity": {
-                    "type": "integer",
-                    "example": 1,
-                    "description": "How many times a voucher has already been redeemed.",
-                    "nullable": true
-                  },
-                  "redeemed_points": {
-                    "type": "integer",
-                    "example": 100000,
-                    "description": "Total loyalty points redeemed.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
-                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionVoucherCategories",
-                "type": "array",
-                "description": "Contains details about the category.",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              },
-              "validation_rules_assignments": {
-                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
-              },
-              "holder": {
-                "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          }
-        },
-        "required": []
-      },
       "RedemptionEntry": {
         "title": "RedemptionEntry",
         "type": "object",
@@ -35561,6 +35071,239 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionEntryPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionEntryPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionEntryPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionEntryPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "$ref": "#/components/schemas/ValidityDayOfWeek"
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "$ref": "#/components/schemas/ValidityDayOfWeek"
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionEntryPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionEntryPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionEntryPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionEntryGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionEntryLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionEntryVoucher",
             "type": "object",
@@ -35829,139 +35572,351 @@
             },
             "nullable": true
           },
+          "reason": {
+            "type": "string",
+            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
+            "nullable": true
+          }
+        }
+      },
+      "RedemptionRedeem": {
+        "title": "RedemptionRedeem",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "r_0bc92f81a6801f9bca",
+            "description": "Unique redemption ID.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "description": "The type of the object represented by the JSON",
+            "default": "redemption",
+            "enum": [
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "example": "2021-12-22T10:13:06.487Z",
+            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "customer_id": {
+            "type": "string",
+            "nullable": true,
+            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
+            "description": "Unique customer ID of the redeeming customer."
+          },
+          "tracking_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Hashed customer source ID."
+          },
+          "metadata": {
+            "title": "RedemptionRedeemMetadata",
+            "type": "object",
+            "nullable": true,
+            "description": "The metadata object stores all custom attributes assigned to the redemption."
+          },
+          "amount": {
+            "type": "integer",
+            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
+            "example": 10000,
+            "nullable": true
+          },
+          "redemption": {
+            "nullable": true,
+            "type": "string",
+            "description": "Unique redemption ID of the parent redemption.",
+            "example": "r_0c656311b5878a2031"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILURE"
+            ],
+            "description": "Redemption result.",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUCCEEDED",
+              "FAILED",
+              "ROLLED_BACK"
+            ],
+            "description": "Redemption status.",
+            "nullable": true
+          },
+          "related_redemptions": {
+            "title": "RedemptionRedeemRelatedRedemptions",
+            "type": "object",
+            "properties": {
+              "rollbacks": {
+                "title": "RedemptionRedeemRelatedRedemptionsRollbacks",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRollbacksItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "rr_0bc92f81a6801f9bca",
+                      "description": "Unique rollback redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              },
+              "redemptions": {
+                "title": "RedemptionRedeemRelatedRedemptionsRedemptions",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRedemptionsItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "r_0bc92f81a6801f9bca",
+                      "description": "Unique redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "failure_code": {
+            "type": "string",
+            "example": "customer_rules_violated",
+            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "failure_message": {
+            "type": "string",
+            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "order": {
+            "$ref": "#/components/schemas/OrderCalculated"
+          },
+          "channel": {
+            "title": "RedemptionRedeemChannel",
+            "type": "object",
+            "description": "Defines the details of the channel through which the redemption was issued.",
+            "properties": {
+              "channel_id": {
+                "type": "string",
+                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
+                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
+                "nullable": true
+              },
+              "channel_type": {
+                "type": "string",
+                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
+                "enum": [
+                  "USER",
+                  "API"
+                ],
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "customer": {
+            "$ref": "#/components/schemas/SimpleCustomer"
+          },
+          "related_object_type": {
+            "type": "string",
+            "description": "Defines the related object.",
+            "enum": [
+              "voucher",
+              "promotion_tier",
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "related_object_id": {
+            "type": "string",
+            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
+            "nullable": true
+          },
           "promotion_tier": {
-            "title": "RedemptionEntryPromotionTier",
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionRedeemGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionRedeemLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "voucher": {
+            "title": "RedemptionRedeemVoucher",
+            "description": "Defines the details of the voucher being redeemed.",
             "type": "object",
             "properties": {
               "id": {
                 "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
+                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
+                "description": "Assigned by the Voucherify API, identifies the voucher.",
                 "nullable": true
               },
-              "created_at": {
+              "code": {
                 "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionEntryPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionEntryPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
+                "example": "WVPblOYX",
+                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
                 "nullable": true
               },
               "campaign": {
-                "title": "RedemptionEntryPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "$ref": "#/components/schemas/ValidityDayOfWeek"
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
+                "type": "string",
+                "example": "Gift Card Campaign",
+                "description": "A unique campaign name, identifies the voucher's parent campaign.",
                 "nullable": true
               },
               "campaign_id": {
                 "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
+                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
+                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
                 "nullable": true
               },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+              "category": {
+                "type": "string",
+                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
+                "nullable": true
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Unique category ID assigned by Voucherify.",
+                "example": "cat_0bb343dee3cdb5ec0c",
+                "nullable": true
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "GIFT_VOUCHER",
+                  "DISCOUNT_VOUCHER",
+                  "LOYALTY_CARD"
+                ],
+                "description": "Defines the type of the voucher. ",
+                "nullable": true
+              },
+              "discount": {
+                "$ref": "#/components/schemas/Discount"
+              },
+              "gift": {
+                "title": "RedemptionRedeemVoucherGift",
+                "type": "object",
+                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
+                "properties": {
+                  "amount": {
+                    "type": "integer",
+                    "example": 10000,
+                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 500,
+                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "effect": {
+                    "type": "string",
+                    "enum": [
+                      "APPLY_TO_ORDER",
+                      "APPLY_TO_ITEMS"
+                    ],
+                    "description": "Defines how the credits are applied to the customer's order.",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "loyalty_card": {
+                "title": "RedemptionRedeemVoucherLoyaltyCard",
+                "type": "object",
+                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
+                "properties": {
+                  "points": {
+                    "type": "integer",
+                    "example": 7000,
+                    "description": "Total points incurred over the lifespan of the loyalty card.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 6970,
+                    "description": "Points available for reward redemption.",
+                    "nullable": true
+                  },
+                  "next_expiration_date": {
+                    "type": "string",
+                    "format": "date",
+                    "example": "2023-05-30",
+                    "description": "The next closest date when the next set of points are due to expire.",
+                    "nullable": true
+                  },
+                  "next_expiration_points": {
+                    "type": "integer",
+                    "description": "The amount of points that are set to expire next.",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "start_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "example": "2021-12-01T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
+                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
                 "nullable": true
               },
               "expiration_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "example": "2021-12-31T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
+                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
                 "nullable": true
               },
               "validity_timeframe": {
@@ -35973,101 +35928,145 @@
               "validity_hours": {
                 "$ref": "#/components/schemas/ValidityHours"
               },
-              "summary": {
-                "title": "RedemptionEntryPromotionTierSummary",
+              "active": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
+              },
+              "additional_info": {
+                "type": "string",
+                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionRedeemVoucherMetadata",
                 "type": "object",
+                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
+                "nullable": true
+              },
+              "assets": {
+                "$ref": "#/components/schemas/VoucherAssets"
+              },
+              "is_referral_code": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-22T10:13:06.487Z",
+                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
+                "format": "date-time",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2021-12-22T10:14:45.316Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
+                "nullable": true
+              },
+              "holder_id": {
+                "type": "string",
+                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
+                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
+                "nullable": true
+              },
+              "referrer_id": {
+                "type": "string",
+                "description": "Unique identifier of the referring person.",
+                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "description": "The type of the object represented by JSON. Default is `voucher`.",
+                "default": "voucher",
+                "nullable": true
+              },
+              "publish": {
+                "title": "RedemptionRedeemVoucherPublish",
+                "type": "object",
+                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
                 "properties": {
-                  "redemptions": {
-                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
                     "nullable": true
                   },
-                  "orders": {
-                    "title": "RedemptionEntryPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
+                  "count": {
+                    "type": "integer",
+                    "example": 0,
+                    "description": "Publication events counter.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
+                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
                     "nullable": true
                   }
                 },
                 "nullable": true
               },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
+              "redemption": {
+                "title": "RedemptionRedeemVoucherRedemption",
+                "type": "object",
+                "description": "Stores a summary of redemptions that have been applied to the voucher.",
+                "properties": {
+                  "quantity": {
+                    "type": "integer",
+                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
+                    "nullable": true
+                  },
+                  "redeemed_quantity": {
+                    "type": "integer",
+                    "example": 1,
+                    "description": "How many times a voucher has already been redeemed.",
+                    "nullable": true
+                  },
+                  "redeemed_points": {
+                    "type": "integer",
+                    "example": 100000,
+                    "description": "Total loyalty points redeemed.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
+                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "categories": {
-                "title": "RedemptionEntryPromotionTierCategories",
+                "title": "RedemptionRedeemVoucherCategories",
                 "type": "array",
+                "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "$ref": "#/components/schemas/CategoryStackingRulesType"
                 },
                 "nullable": true
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              },
+              "holder": {
+                "$ref": "#/components/schemas/SimpleCustomer"
               }
             },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionEntryGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionEntryLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-              }
-            },
-            "nullable": true
-          },
-          "reason": {
-            "type": "string",
-            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
             "nullable": true
           }
-        }
+        },
+        "description": "This is an object representing a redemption for **POST** `v1/redemptions`, **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption`, **POST** `v1/loyalties/members/{memberId}/redemption`, **POST** `/client/v1/redemptions`."
       },
       "RedemptionRewardResult": {
         "title": "RedemptionRewardResult",

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -36052,7 +36052,7 @@
                 "type": "array",
                 "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                  "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                 },
                 "nullable": true
               },

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -2594,12 +2594,12 @@
             "title": "ClientRedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -9442,6 +9442,38 @@
             "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
             "nullable": true
           },
+          "promotion_tier": {
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucher",
             "description": "Defines the details of the voucher being redeemed.",
@@ -9701,9 +9733,9 @@
               "categories": {
                 "title": "LoyaltiesMembersRedemptionRedeemResponseBodyVoucherCategories",
                 "type": "array",
-                "description": "Contains details about the category.",
+                "description": "Always returns an empty array.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "title": "MembersRedemptionVoucherCategoriesItem"
                 },
                 "nullable": true
               },
@@ -9712,38 +9744,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "LoyaltiesMembersRedemptionRedeemResponseBodyLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
               }
             },
             "nullable": true
@@ -21463,6 +21463,239 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionsGetResponseBodyPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionsGetResponseBodyPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "$ref": "#/components/schemas/ValidityDayOfWeek"
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "$ref": "#/components/schemas/ValidityDayOfWeek"
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionsGetResponseBodyGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionsGetResponseBodyLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionsGetResponseBodyVoucher",
             "type": "object",
@@ -21727,239 +21960,6 @@
               },
               "holder": {
                 "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "title": "RedemptionsGetResponseBodyPromotionTier",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
-                "nullable": true
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionsGetResponseBodyPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionsGetResponseBodyPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
-                "nullable": true
-              },
-              "campaign": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "$ref": "#/components/schemas/ValidityDayOfWeek"
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
-                "nullable": true
-              },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "$ref": "#/components/schemas/ValidityDayOfWeek"
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "summary": {
-                "title": "RedemptionsGetResponseBodyPromotionTierSummary",
-                "type": "object",
-                "properties": {
-                  "redemptions": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  },
-                  "orders": {
-                    "title": "RedemptionsGetResponseBodyPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionsGetResponseBodyPromotionTierCategories",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionsGetResponseBodyGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionsGetResponseBodyLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
               }
             },
             "nullable": true
@@ -22346,6 +22346,228 @@
                 "related_object_id": {
                   "type": "string"
                 },
+                "promotion_tier": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                      "description": "Unique promotion tier ID.",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "example": "2021-12-15T11:34:01.333Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2022-02-09T09:20:05.603Z",
+                      "format": "date-time",
+                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the promotion tier.",
+                      "nullable": true
+                    },
+                    "banner": {
+                      "type": "string",
+                      "description": "Text to be displayed to your customers on your website.",
+                      "nullable": true
+                    },
+                    "action": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
+                      "type": "object",
+                      "properties": {
+                        "discount": {
+                          "$ref": "#/components/schemas/Discount"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
+                      "type": "object"
+                    },
+                    "hierarchy": {
+                      "type": "integer",
+                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                      "nullable": true
+                    },
+                    "promotion_id": {
+                      "type": "string",
+                      "description": "Promotion unique ID.",
+                      "nullable": true
+                    },
+                    "campaign": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique campaign ID.",
+                          "nullable": true
+                        },
+                        "start_date": {
+                          "type": "string",
+                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                          "format": "date-time",
+                          "example": "2022-09-22T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "expiration_date": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                          "example": "2022-09-30T00:00:00.000Z",
+                          "nullable": true
+                        },
+                        "validity_timeframe": {
+                          "$ref": "#/components/schemas/ValidityTimeframe"
+                        },
+                        "validity_day_of_week": {
+                          "$ref": "#/components/schemas/ValidityDayOfWeek"
+                        },
+                        "validity_hours": {
+                          "$ref": "#/components/schemas/ValidityHours"
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                          "nullable": true
+                        },
+                        "category_id": {
+                          "type": "string",
+                          "example": "cat_0b688929a2476386a6",
+                          "description": "Unique category ID that this campaign belongs to.",
+                          "nullable": true
+                        },
+                        "object": {
+                          "type": "string",
+                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                          "default": "campaign",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "campaign_id": {
+                      "type": "string",
+                      "description": "Promotion tier's parent campaign's unique ID.",
+                      "nullable": true
+                    },
+                    "active": {
+                      "type": "boolean",
+                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                      "nullable": true
+                    },
+                    "start_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-23T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "expiration_date": {
+                      "type": "string",
+                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                      "format": "date-time",
+                      "example": "2022-09-26T00:00:00.000Z",
+                      "nullable": true
+                    },
+                    "validity_timeframe": {
+                      "$ref": "#/components/schemas/ValidityTimeframe"
+                    },
+                    "validity_day_of_week": {
+                      "$ref": "#/components/schemas/ValidityDayOfWeek"
+                    },
+                    "validity_hours": {
+                      "$ref": "#/components/schemas/ValidityHours"
+                    },
+                    "summary": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
+                      "type": "object",
+                      "properties": {
+                        "redemptions": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
+                          "type": "object",
+                          "properties": {
+                            "total_redeemed": {
+                              "type": "integer",
+                              "description": "Number of times the promotion tier was redeemed.",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "orders": {
+                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
+                          "type": "object",
+                          "properties": {
+                            "total_amount": {
+                              "type": "integer",
+                              "description": "Sum of order totals.",
+                              "nullable": true
+                            },
+                            "total_discount_amount": {
+                              "type": "integer",
+                              "description": "Sum of total discount applied using the promotion tier.",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object": {
+                      "type": "string",
+                      "default": "promotion_tier",
+                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                      "nullable": true
+                    },
+                    "validation_rule_assignments": {
+                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+                    },
+                    "category_id": {
+                      "type": "string",
+                      "description": "Promotion tier category ID.",
+                      "example": "cat_0c9da30e7116ba6bba",
+                      "nullable": true
+                    },
+                    "categories": {
+                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Category"
+                      },
+                      "nullable": true
+                    }
+                  }
+                },
+                "reward": {
+                  "$ref": "#/components/schemas/RedemptionRewardResult"
+                },
+                "gift": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "type": "integer",
+                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+                    }
+                  }
+                },
+                "loyalty_card": {
+                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
+                  "type": "object",
+                  "properties": {
+                    "points": {
+                      "type": "integer",
+                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+                    }
+                  }
+                },
                 "voucher": {
                   "title": "RedemptionsListResponseBodyRedemptionsItemVoucher",
                   "type": "object",
@@ -22608,228 +22830,6 @@
                     }
                   }
                 },
-                "promotion_tier": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTier",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                      "description": "Unique promotion tier ID.",
-                      "nullable": true
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "example": "2021-12-15T11:34:01.333Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "example": "2022-02-09T09:20:05.603Z",
-                      "format": "date-time",
-                      "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                      "nullable": true
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Name of the promotion tier.",
-                      "nullable": true
-                    },
-                    "banner": {
-                      "type": "string",
-                      "description": "Text to be displayed to your customers on your website.",
-                      "nullable": true
-                    },
-                    "action": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierAction",
-                      "type": "object",
-                      "properties": {
-                        "discount": {
-                          "$ref": "#/components/schemas/Discount"
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierMetadata",
-                      "type": "object"
-                    },
-                    "hierarchy": {
-                      "type": "integer",
-                      "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                      "nullable": true
-                    },
-                    "promotion_id": {
-                      "type": "string",
-                      "description": "Promotion unique ID.",
-                      "nullable": true
-                    },
-                    "campaign": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCampaign",
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "Unique campaign ID.",
-                          "nullable": true
-                        },
-                        "start_date": {
-                          "type": "string",
-                          "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                          "format": "date-time",
-                          "example": "2022-09-22T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "expiration_date": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                          "example": "2022-09-30T00:00:00.000Z",
-                          "nullable": true
-                        },
-                        "validity_timeframe": {
-                          "$ref": "#/components/schemas/ValidityTimeframe"
-                        },
-                        "validity_day_of_week": {
-                          "$ref": "#/components/schemas/ValidityDayOfWeek"
-                        },
-                        "validity_hours": {
-                          "$ref": "#/components/schemas/ValidityHours"
-                        },
-                        "active": {
-                          "type": "boolean",
-                          "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                          "nullable": true
-                        },
-                        "category_id": {
-                          "type": "string",
-                          "example": "cat_0b688929a2476386a6",
-                          "description": "Unique category ID that this campaign belongs to.",
-                          "nullable": true
-                        },
-                        "object": {
-                          "type": "string",
-                          "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                          "default": "campaign",
-                          "nullable": true
-                        }
-                      }
-                    },
-                    "campaign_id": {
-                      "type": "string",
-                      "description": "Promotion tier's parent campaign's unique ID.",
-                      "nullable": true
-                    },
-                    "active": {
-                      "type": "boolean",
-                      "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
-                      "nullable": true
-                    },
-                    "start_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-23T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "expiration_date": {
-                      "type": "string",
-                      "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
-                      "format": "date-time",
-                      "example": "2022-09-26T00:00:00.000Z",
-                      "nullable": true
-                    },
-                    "validity_timeframe": {
-                      "$ref": "#/components/schemas/ValidityTimeframe"
-                    },
-                    "validity_day_of_week": {
-                      "$ref": "#/components/schemas/ValidityDayOfWeek"
-                    },
-                    "validity_hours": {
-                      "$ref": "#/components/schemas/ValidityHours"
-                    },
-                    "summary": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummary",
-                      "type": "object",
-                      "properties": {
-                        "redemptions": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryRedemptions",
-                          "type": "object",
-                          "properties": {
-                            "total_redeemed": {
-                              "type": "integer",
-                              "description": "Number of times the promotion tier was redeemed.",
-                              "nullable": true
-                            }
-                          }
-                        },
-                        "orders": {
-                          "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierSummaryOrders",
-                          "type": "object",
-                          "properties": {
-                            "total_amount": {
-                              "type": "integer",
-                              "description": "Sum of order totals.",
-                              "nullable": true
-                            },
-                            "total_discount_amount": {
-                              "type": "integer",
-                              "description": "Sum of total discount applied using the promotion tier.",
-                              "nullable": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "object": {
-                      "type": "string",
-                      "default": "promotion_tier",
-                      "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                      "nullable": true
-                    },
-                    "validation_rule_assignments": {
-                      "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-                    },
-                    "category_id": {
-                      "type": "string",
-                      "description": "Promotion tier category ID.",
-                      "example": "cat_0c9da30e7116ba6bba",
-                      "nullable": true
-                    },
-                    "categories": {
-                      "title": "RedemptionsListResponseBodyRedemptionsItemPromotionTierCategories",
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Category"
-                      },
-                      "nullable": true
-                    }
-                  }
-                },
-                "reward": {
-                  "$ref": "#/components/schemas/RedemptionRewardResult"
-                },
-                "gift": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemGift",
-                  "type": "object",
-                  "properties": {
-                    "amount": {
-                      "type": "integer",
-                      "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-                    }
-                  }
-                },
-                "loyalty_card": {
-                  "title": "RedemptionsListResponseBodyRedemptionsItemLoyaltyCard",
-                  "type": "object",
-                  "properties": {
-                    "points": {
-                      "type": "integer",
-                      "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-                    }
-                  }
-                },
                 "reason": {
                   "type": "string",
                   "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
@@ -22961,12 +22961,12 @@
             "title": "RedemptionsRedeemResponseBodyRedemptions",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Redemption"
+              "$ref": "#/components/schemas/RedemptionRedeem"
             },
             "nullable": true
           },
           "parent_redemption": {
-            "$ref": "#/components/schemas/Redemption"
+            "$ref": "#/components/schemas/RedemptionRedeem"
           },
           "order": {
             "$ref": "#/components/schemas/OrderCalculated"
@@ -35275,496 +35275,6 @@
         },
         "required": []
       },
-      "Redemption": {
-        "title": "Redemption",
-        "type": "object",
-        "description": "This is an object representing a redemption.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "r_0bc92f81a6801f9bca",
-            "description": "Unique redemption ID.",
-            "nullable": true
-          },
-          "object": {
-            "type": "string",
-            "description": "The type of the object represented by the JSON",
-            "default": "redemption",
-            "enum": [
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "date": {
-            "type": "string",
-            "example": "2021-12-22T10:13:06.487Z",
-            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "customer_id": {
-            "type": "string",
-            "nullable": true,
-            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
-            "description": "Unique customer ID of the redeeming customer."
-          },
-          "tracking_id": {
-            "type": "string",
-            "nullable": true,
-            "description": "Hashed customer source ID."
-          },
-          "metadata": {
-            "title": "RedemptionMetadata",
-            "type": "object",
-            "nullable": true,
-            "description": "The metadata object stores all custom attributes assigned to the redemption."
-          },
-          "amount": {
-            "type": "integer",
-            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
-            "example": 10000,
-            "nullable": true
-          },
-          "redemption": {
-            "nullable": true,
-            "type": "string",
-            "description": "Unique redemption ID of the parent redemption.",
-            "example": "r_0c656311b5878a2031"
-          },
-          "result": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILURE"
-            ],
-            "description": "Redemption result.",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "SUCCEEDED",
-              "FAILED",
-              "ROLLED_BACK"
-            ],
-            "description": "Redemption status.",
-            "nullable": true
-          },
-          "related_redemptions": {
-            "title": "RedemptionRelatedRedemptions",
-            "type": "object",
-            "properties": {
-              "rollbacks": {
-                "title": "RedemptionRelatedRedemptionsRollbacks",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRollbacksItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "rr_0bc92f81a6801f9bca",
-                      "description": "Unique rollback redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              },
-              "redemptions": {
-                "title": "RedemptionRelatedRedemptionsRedemptions",
-                "type": "array",
-                "items": {
-                  "title": "RedemptionRelatedRedemptionsRedemptionsItem",
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "example": "r_0bc92f81a6801f9bca",
-                      "description": "Unique redemption ID."
-                    },
-                    "date": {
-                      "type": "string",
-                      "example": "2021-12-22T10:13:06.487Z",
-                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
-                      "format": "date-time"
-                    }
-                  }
-                },
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "failure_code": {
-            "type": "string",
-            "example": "customer_rules_violated",
-            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "failure_message": {
-            "type": "string",
-            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
-            "nullable": true
-          },
-          "order": {
-            "$ref": "#/components/schemas/OrderCalculated"
-          },
-          "channel": {
-            "title": "RedemptionChannel",
-            "type": "object",
-            "description": "Defines the details of the channel through which the redemption was issued.",
-            "properties": {
-              "channel_id": {
-                "type": "string",
-                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
-                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
-                "nullable": true
-              },
-              "channel_type": {
-                "type": "string",
-                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
-                "enum": [
-                  "USER",
-                  "API"
-                ],
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "customer": {
-            "$ref": "#/components/schemas/SimpleCustomer"
-          },
-          "related_object_type": {
-            "type": "string",
-            "description": "Defines the related object.",
-            "enum": [
-              "voucher",
-              "promotion_tier",
-              "redemption"
-            ],
-            "nullable": true
-          },
-          "related_object_id": {
-            "type": "string",
-            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
-            "nullable": true
-          },
-          "voucher": {
-            "title": "RedemptionVoucher",
-            "description": "Defines the details of the voucher being redeemed.",
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
-                "description": "Assigned by the Voucherify API, identifies the voucher.",
-                "nullable": true
-              },
-              "code": {
-                "type": "string",
-                "example": "WVPblOYX",
-                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
-                "nullable": true
-              },
-              "campaign": {
-                "type": "string",
-                "example": "Gift Card Campaign",
-                "description": "A unique campaign name, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "campaign_id": {
-                "type": "string",
-                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
-                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
-                "nullable": true
-              },
-              "category": {
-                "type": "string",
-                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
-                "nullable": true
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Unique category ID assigned by Voucherify.",
-                "example": "cat_0bb343dee3cdb5ec0c",
-                "nullable": true
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "GIFT_VOUCHER",
-                  "DISCOUNT_VOUCHER",
-                  "LOYALTY_CARD"
-                ],
-                "description": "Defines the type of the voucher. ",
-                "nullable": true
-              },
-              "discount": {
-                "$ref": "#/components/schemas/Discount"
-              },
-              "gift": {
-                "title": "RedemptionVoucherGift",
-                "type": "object",
-                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
-                "properties": {
-                  "amount": {
-                    "type": "integer",
-                    "example": 10000,
-                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 500,
-                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
-                    "nullable": true
-                  },
-                  "effect": {
-                    "type": "string",
-                    "enum": [
-                      "APPLY_TO_ORDER",
-                      "APPLY_TO_ITEMS"
-                    ],
-                    "description": "Defines how the credits are applied to the customer's order.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "loyalty_card": {
-                "title": "RedemptionVoucherLoyaltyCard",
-                "type": "object",
-                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
-                "properties": {
-                  "points": {
-                    "type": "integer",
-                    "example": 7000,
-                    "description": "Total points incurred over the lifespan of the loyalty card.",
-                    "nullable": true
-                  },
-                  "balance": {
-                    "type": "integer",
-                    "example": 6970,
-                    "description": "Points available for reward redemption.",
-                    "nullable": true
-                  },
-                  "next_expiration_date": {
-                    "type": "string",
-                    "format": "date",
-                    "example": "2023-05-30",
-                    "description": "The next closest date when the next set of points are due to expire.",
-                    "nullable": true
-                  },
-                  "next_expiration_points": {
-                    "type": "integer",
-                    "description": "The amount of points that are set to expire next.",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "start_date": {
-                "type": "string",
-                "example": "2021-12-01T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
-                "nullable": true
-              },
-              "expiration_date": {
-                "type": "string",
-                "example": "2021-12-31T00:00:00.000Z",
-                "format": "date-time",
-                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
-                "nullable": true
-              },
-              "validity_timeframe": {
-                "$ref": "#/components/schemas/ValidityTimeframe"
-              },
-              "validity_day_of_week": {
-                "$ref": "#/components/schemas/ValidityDayOfWeek"
-              },
-              "validity_hours": {
-                "$ref": "#/components/schemas/ValidityHours"
-              },
-              "active": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
-              },
-              "additional_info": {
-                "type": "string",
-                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionVoucherMetadata",
-                "type": "object",
-                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
-                "nullable": true
-              },
-              "assets": {
-                "$ref": "#/components/schemas/VoucherAssets"
-              },
-              "is_referral_code": {
-                "type": "boolean",
-                "nullable": true,
-                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
-              },
-              "created_at": {
-                "type": "string",
-                "example": "2021-12-22T10:13:06.487Z",
-                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
-                "format": "date-time",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2021-12-22T10:14:45.316Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
-                "nullable": true
-              },
-              "holder_id": {
-                "type": "string",
-                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
-                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
-                "nullable": true
-              },
-              "referrer_id": {
-                "type": "string",
-                "description": "Unique identifier of the referring person.",
-                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
-                "nullable": true
-              },
-              "object": {
-                "type": "string",
-                "description": "The type of the object represented by JSON. Default is `voucher`.",
-                "default": "voucher",
-                "nullable": true
-              },
-              "publish": {
-                "title": "RedemptionVoucherPublish",
-                "type": "object",
-                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
-                "properties": {
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
-                    "nullable": true
-                  },
-                  "count": {
-                    "type": "integer",
-                    "example": 0,
-                    "description": "Publication events counter.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
-                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "redemption": {
-                "title": "RedemptionVoucherRedemption",
-                "type": "object",
-                "description": "Stores a summary of redemptions that have been applied to the voucher.",
-                "properties": {
-                  "quantity": {
-                    "type": "integer",
-                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
-                    "nullable": true
-                  },
-                  "redeemed_quantity": {
-                    "type": "integer",
-                    "example": 1,
-                    "description": "How many times a voucher has already been redeemed.",
-                    "nullable": true
-                  },
-                  "redeemed_points": {
-                    "type": "integer",
-                    "example": 100000,
-                    "description": "Total loyalty points redeemed.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "default": "list",
-                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
-                    "nullable": true
-                  },
-                  "url": {
-                    "type": "string",
-                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
-                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
-                    "nullable": true
-                  }
-                },
-                "nullable": true
-              },
-              "categories": {
-                "title": "RedemptionVoucherCategories",
-                "type": "array",
-                "description": "Contains details about the category.",
-                "items": {
-                  "$ref": "#/components/schemas/Category"
-                },
-                "nullable": true
-              },
-              "validation_rules_assignments": {
-                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
-              },
-              "holder": {
-                "$ref": "#/components/schemas/SimpleCustomer"
-              }
-            },
-            "nullable": true
-          },
-          "promotion_tier": {
-            "$ref": "#/components/schemas/PromotionTier"
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionGift",
-            "type": "object",
-            "description": "Contains the amount subtracted from the gift card for the redemption.",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionLoyaltyCard",
-            "type": "object",
-            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
-                "nullable": true
-              }
-            },
-            "nullable": true
-          }
-        },
-        "required": []
-      },
       "RedemptionEntry": {
         "title": "RedemptionEntry",
         "type": "object",
@@ -36137,6 +35647,239 @@
             "type": "string",
             "nullable": true
           },
+          "promotion_tier": {
+            "title": "RedemptionEntryPromotionTier",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
+                "description": "Unique promotion tier ID.",
+                "nullable": true
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-15T11:34:01.333Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2022-02-09T09:20:05.603Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
+                "nullable": true
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the promotion tier.",
+                "nullable": true
+              },
+              "banner": {
+                "type": "string",
+                "description": "Text to be displayed to your customers on your website.",
+                "nullable": true
+              },
+              "action": {
+                "title": "RedemptionEntryPromotionTierAction",
+                "type": "object",
+                "properties": {
+                  "discount": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
+                },
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionEntryPromotionTierMetadata",
+                "type": "object",
+                "nullable": true
+              },
+              "hierarchy": {
+                "type": "integer",
+                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
+                "nullable": true
+              },
+              "promotion_id": {
+                "type": "string",
+                "description": "Promotion unique ID.",
+                "nullable": true
+              },
+              "campaign": {
+                "title": "RedemptionEntryPromotionTierCampaign",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Unique campaign ID.",
+                    "nullable": true
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
+                    "format": "date-time",
+                    "example": "2022-09-22T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "expiration_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
+                    "example": "2022-09-30T00:00:00.000Z",
+                    "nullable": true
+                  },
+                  "validity_timeframe": {
+                    "$ref": "#/components/schemas/ValidityTimeframe"
+                  },
+                  "validity_day_of_week": {
+                    "$ref": "#/components/schemas/ValidityDayOfWeek"
+                  },
+                  "validity_hours": {
+                    "$ref": "#/components/schemas/ValidityHours"
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
+                    "nullable": true
+                  },
+                  "category_id": {
+                    "type": "string",
+                    "example": "cat_0b688929a2476386a6",
+                    "description": "Unique category ID that this campaign belongs to.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
+                    "default": "campaign",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "campaign_id": {
+                "type": "string",
+                "description": "Promotion tier's parent campaign's unique ID.",
+                "nullable": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "format": "date-time",
+                "example": "2022-09-23T00:00:00.000Z",
+                "nullable": true
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "format": "date-time",
+                "example": "2022-09-26T00:00:00.000Z",
+                "nullable": true
+              },
+              "validity_timeframe": {
+                "$ref": "#/components/schemas/ValidityTimeframe"
+              },
+              "validity_day_of_week": {
+                "$ref": "#/components/schemas/ValidityDayOfWeek"
+              },
+              "validity_hours": {
+                "$ref": "#/components/schemas/ValidityHours"
+              },
+              "summary": {
+                "title": "RedemptionEntryPromotionTierSummary",
+                "type": "object",
+                "properties": {
+                  "redemptions": {
+                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
+                    "type": "object",
+                    "properties": {
+                      "total_redeemed": {
+                        "type": "integer",
+                        "description": "Number of times the promotion tier was redeemed.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "orders": {
+                    "title": "RedemptionEntryPromotionTierSummaryOrders",
+                    "type": "object",
+                    "properties": {
+                      "total_amount": {
+                        "type": "integer",
+                        "description": "Sum of order totals.",
+                        "nullable": true
+                      },
+                      "total_discount_amount": {
+                        "type": "integer",
+                        "description": "Sum of total discount applied using the promotion tier.",
+                        "nullable": true
+                      }
+                    },
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "default": "promotion_tier",
+                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
+                "nullable": true
+              },
+              "validation_rule_assignments": {
+                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Promotion tier category ID.",
+                "example": "cat_0c9da30e7116ba6bba",
+                "nullable": true
+              },
+              "categories": {
+                "title": "RedemptionEntryPromotionTierCategories",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Category"
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionEntryGift",
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionEntryLoyaltyCard",
+            "type": "object",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
+              }
+            },
+            "nullable": true
+          },
           "voucher": {
             "title": "RedemptionEntryVoucher",
             "type": "object",
@@ -36405,139 +36148,351 @@
             },
             "nullable": true
           },
+          "reason": {
+            "type": "string",
+            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
+            "nullable": true
+          }
+        }
+      },
+      "RedemptionRedeem": {
+        "title": "RedemptionRedeem",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "r_0bc92f81a6801f9bca",
+            "description": "Unique redemption ID.",
+            "nullable": true
+          },
+          "object": {
+            "type": "string",
+            "description": "The type of the object represented by the JSON",
+            "default": "redemption",
+            "enum": [
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "example": "2021-12-22T10:13:06.487Z",
+            "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "customer_id": {
+            "type": "string",
+            "nullable": true,
+            "example": "cust_i8t5Tt6eiKG5K79KQlJ0Vs64",
+            "description": "Unique customer ID of the redeeming customer."
+          },
+          "tracking_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Hashed customer source ID."
+          },
+          "metadata": {
+            "title": "RedemptionRedeemMetadata",
+            "type": "object",
+            "nullable": true,
+            "description": "The metadata object stores all custom attributes assigned to the redemption."
+          },
+          "amount": {
+            "type": "integer",
+            "description": "For gift cards, this is a positive integer in the smallest currency unit (e.g. 100 cents for $1.00) representing the number of redeemed credits.\nFor loyalty cards, this is the number of loyalty points used in the transaction.",
+            "example": 10000,
+            "nullable": true
+          },
+          "redemption": {
+            "nullable": true,
+            "type": "string",
+            "description": "Unique redemption ID of the parent redemption.",
+            "example": "r_0c656311b5878a2031"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILURE"
+            ],
+            "description": "Redemption result.",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUCCEEDED",
+              "FAILED",
+              "ROLLED_BACK"
+            ],
+            "description": "Redemption status.",
+            "nullable": true
+          },
+          "related_redemptions": {
+            "title": "RedemptionRedeemRelatedRedemptions",
+            "type": "object",
+            "properties": {
+              "rollbacks": {
+                "title": "RedemptionRedeemRelatedRedemptionsRollbacks",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRollbacksItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "rr_0bc92f81a6801f9bca",
+                      "description": "Unique rollback redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              },
+              "redemptions": {
+                "title": "RedemptionRedeemRelatedRedemptionsRedemptions",
+                "type": "array",
+                "items": {
+                  "title": "RedemptionRedeemRelatedRedemptionsRedemptionsItem",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "r_0bc92f81a6801f9bca",
+                      "description": "Unique redemption ID."
+                    },
+                    "date": {
+                      "type": "string",
+                      "example": "2021-12-22T10:13:06.487Z",
+                      "description": "Timestamp representing the date and time when the object was created. The value is shown in the ISO 8601 format.",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "failure_code": {
+            "type": "string",
+            "example": "customer_rules_violated",
+            "description": "If the result is `FAILURE`, this parameter will provide a generic reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "failure_message": {
+            "type": "string",
+            "description": "If the result is `FAILURE`, this parameter will provide a more expanded reason as to why the redemption failed.",
+            "nullable": true
+          },
+          "order": {
+            "$ref": "#/components/schemas/OrderCalculated"
+          },
+          "channel": {
+            "title": "RedemptionRedeemChannel",
+            "type": "object",
+            "description": "Defines the details of the channel through which the redemption was issued.",
+            "properties": {
+              "channel_id": {
+                "type": "string",
+                "example": "user_g24UoRO3Caxu7FCT4n5tpYEa3zUG0FrH",
+                "description": "Unique channel ID of the user performing the redemption. This is either a user ID from a user using the Voucherify Dashboard or an X-APP-Id of a user using the API.",
+                "nullable": true
+              },
+              "channel_type": {
+                "type": "string",
+                "description": "The source of the channel for the redemption. A `USER` corresponds to the Voucherify Dashboard and an `API` corresponds to the API.",
+                "enum": [
+                  "USER",
+                  "API"
+                ],
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "customer": {
+            "$ref": "#/components/schemas/SimpleCustomer"
+          },
+          "related_object_type": {
+            "type": "string",
+            "description": "Defines the related object.",
+            "enum": [
+              "voucher",
+              "promotion_tier",
+              "redemption"
+            ],
+            "nullable": true
+          },
+          "related_object_id": {
+            "type": "string",
+            "description": "Unique related object ID assigned by Voucherify, i.e. v_lfZi4rcEGe0sN9gmnj40bzwK2FH6QUno for a voucher.",
+            "nullable": true
+          },
           "promotion_tier": {
-            "title": "RedemptionEntryPromotionTier",
+            "$ref": "#/components/schemas/PromotionTier"
+          },
+          "reward": {
+            "$ref": "#/components/schemas/RedemptionRewardResult"
+          },
+          "gift": {
+            "title": "RedemptionRedeemGift",
+            "type": "object",
+            "description": "Contains the amount subtracted from the gift card for the redemption.",
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00).",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "loyalty_card": {
+            "title": "RedemptionRedeemLoyaltyCard",
+            "type": "object",
+            "description": "Contains the number of points subtracted from the loyalty card for the redemption.",
+            "properties": {
+              "points": {
+                "type": "integer",
+                "description": "Number of points subtracted from the loyalty card as a result of the redemption.",
+                "nullable": true
+              }
+            },
+            "nullable": true
+          },
+          "voucher": {
+            "title": "RedemptionRedeemVoucher",
+            "description": "Defines the details of the voucher being redeemed.",
             "type": "object",
             "properties": {
               "id": {
                 "type": "string",
-                "example": "promo_63fYCt81Aw0h7lzyRkrGZh9p",
-                "description": "Unique promotion tier ID.",
+                "example": "v_mkZN9v7vjYUadXnHrMza8W5c34fE5KiV",
+                "description": "Assigned by the Voucherify API, identifies the voucher.",
                 "nullable": true
               },
-              "created_at": {
+              "code": {
                 "type": "string",
-                "example": "2021-12-15T11:34:01.333Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was created. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "updated_at": {
-                "type": "string",
-                "example": "2022-02-09T09:20:05.603Z",
-                "format": "date-time",
-                "description": "Timestamp representing the date and time when the promotion tier was updated. The value is shown in the ISO 8601 format.",
-                "nullable": true
-              },
-              "name": {
-                "type": "string",
-                "description": "Name of the promotion tier.",
-                "nullable": true
-              },
-              "banner": {
-                "type": "string",
-                "description": "Text to be displayed to your customers on your website.",
-                "nullable": true
-              },
-              "action": {
-                "title": "RedemptionEntryPromotionTierAction",
-                "type": "object",
-                "properties": {
-                  "discount": {
-                    "$ref": "#/components/schemas/Discount"
-                  }
-                },
-                "nullable": true
-              },
-              "metadata": {
-                "title": "RedemptionEntryPromotionTierMetadata",
-                "type": "object",
-                "nullable": true
-              },
-              "hierarchy": {
-                "type": "integer",
-                "description": "The promotions hierarchy defines the order in which the discounts from different tiers will be applied to a customer's order. If a customer qualifies for discounts from more than one tier, discounts will be applied in the order defined in the hierarchy.",
-                "nullable": true
-              },
-              "promotion_id": {
-                "type": "string",
-                "description": "Promotion unique ID.",
+                "example": "WVPblOYX",
+                "description": "A code that identifies a voucher. Pattern can use all letters of the English alphabet, Arabic numerals, and special characters.",
                 "nullable": true
               },
               "campaign": {
-                "title": "RedemptionEntryPromotionTierCampaign",
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique campaign ID.",
-                    "nullable": true
-                  },
-                  "start_date": {
-                    "type": "string",
-                    "description": "Activation timestamp defines when the campaign starts to be active in ISO 8601 format. Campaign is *inactive before* this date. ",
-                    "format": "date-time",
-                    "example": "2022-09-22T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "expiration_date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Expiration timestamp defines when the campaign expires in ISO 8601 format.  Campaign is *inactive after* this date.",
-                    "example": "2022-09-30T00:00:00.000Z",
-                    "nullable": true
-                  },
-                  "validity_timeframe": {
-                    "$ref": "#/components/schemas/ValidityTimeframe"
-                  },
-                  "validity_day_of_week": {
-                    "$ref": "#/components/schemas/ValidityDayOfWeek"
-                  },
-                  "validity_hours": {
-                    "$ref": "#/components/schemas/ValidityHours"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "A flag indicating whether the campaign is active or not active. A campaign can be disabled even though it's within the active period defined by the `start_date` and `expiration_date` using the <!-- [Disable Campaign](OpenAPI.json/paths/~1campaigns~1{campaignId}~1disable) -->[Disable Campaign](ref:disable-campaign) endpoint.  \n\n- `true` indicates an *active* campaign\n- `false` indicates an *inactive* campaign",
-                    "nullable": true
-                  },
-                  "category_id": {
-                    "type": "string",
-                    "example": "cat_0b688929a2476386a6",
-                    "description": "Unique category ID that this campaign belongs to.",
-                    "nullable": true
-                  },
-                  "object": {
-                    "type": "string",
-                    "description": "The type of the object represented by the campaign object. This object stores information about the campaign.",
-                    "default": "campaign",
-                    "nullable": true
-                  }
-                },
+                "type": "string",
+                "example": "Gift Card Campaign",
+                "description": "A unique campaign name, identifies the voucher's parent campaign.",
                 "nullable": true
               },
               "campaign_id": {
                 "type": "string",
-                "description": "Promotion tier's parent campaign's unique ID.",
+                "example": "camp_FNYR4jhqZBM9xTptxDGgeNBV",
+                "description": "Assigned by the Voucherify API, identifies the voucher's parent campaign.",
                 "nullable": true
               },
-              "active": {
-                "type": "boolean",
-                "description": "A flag to toggle the promotion tier on or off. You can disable a promotion tier even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* promotion tier\n- `false` indicates an *inactive* promotion tier",
+              "category": {
+                "type": "string",
+                "description": "Tag defining the category that this voucher belongs to. Useful when listing vouchers using the List Vouchers endpoint.",
+                "nullable": true
+              },
+              "category_id": {
+                "type": "string",
+                "description": "Unique category ID assigned by Voucherify.",
+                "example": "cat_0bb343dee3cdb5ec0c",
+                "nullable": true
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "GIFT_VOUCHER",
+                  "DISCOUNT_VOUCHER",
+                  "LOYALTY_CARD"
+                ],
+                "description": "Defines the type of the voucher. ",
+                "nullable": true
+              },
+              "discount": {
+                "$ref": "#/components/schemas/Discount"
+              },
+              "gift": {
+                "title": "RedemptionRedeemVoucherGift",
+                "type": "object",
+                "description": "Object representing gift parameters. Child attributes are present only if `type` is `GIFT_VOUCHER`. Defaults to `null`.",
+                "properties": {
+                  "amount": {
+                    "type": "integer",
+                    "example": 10000,
+                    "description": "Total gift card income over the lifetime of the card. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 500,
+                    "description": "Available funds. Value is multiplied by 100 to precisely represent 2 decimal places. For example, $100 amount is written as 10000.",
+                    "nullable": true
+                  },
+                  "effect": {
+                    "type": "string",
+                    "enum": [
+                      "APPLY_TO_ORDER",
+                      "APPLY_TO_ITEMS"
+                    ],
+                    "description": "Defines how the credits are applied to the customer's order.",
+                    "nullable": true
+                  }
+                },
+                "nullable": true
+              },
+              "loyalty_card": {
+                "title": "RedemptionRedeemVoucherLoyaltyCard",
+                "type": "object",
+                "description": "Object representing loyalty card parameters. Child attributes are present only if `type` is `LOYALTY_CARD`. Defaults to `null`.",
+                "properties": {
+                  "points": {
+                    "type": "integer",
+                    "example": 7000,
+                    "description": "Total points incurred over the lifespan of the loyalty card.",
+                    "nullable": true
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "example": 6970,
+                    "description": "Points available for reward redemption.",
+                    "nullable": true
+                  },
+                  "next_expiration_date": {
+                    "type": "string",
+                    "format": "date",
+                    "example": "2023-05-30",
+                    "description": "The next closest date when the next set of points are due to expire.",
+                    "nullable": true
+                  },
+                  "next_expiration_points": {
+                    "type": "integer",
+                    "description": "The amount of points that are set to expire next.",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "start_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier starts to be active in ISO 8601 format. Promotion tier is *inactive before* this date. ",
+                "example": "2021-12-01T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-23T00:00:00.000Z",
+                "description": "Activation timestamp defines when the code starts to be active in ISO 8601 format. Voucher is *inactive before* this date. ",
                 "nullable": true
               },
               "expiration_date": {
                 "type": "string",
-                "description": "Activation timestamp defines when the promotion tier expires in ISO 8601 format. Promotion tier is *inactive after* this date. ",
+                "example": "2021-12-31T00:00:00.000Z",
                 "format": "date-time",
-                "example": "2022-09-26T00:00:00.000Z",
+                "description": "Expiration timestamp defines when the code expires in ISO 8601 format.  Voucher is *inactive after* this date.",
                 "nullable": true
               },
               "validity_timeframe": {
@@ -36549,101 +36504,145 @@
               "validity_hours": {
                 "$ref": "#/components/schemas/ValidityHours"
               },
-              "summary": {
-                "title": "RedemptionEntryPromotionTierSummary",
+              "active": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "A flag to toggle the voucher on or off. You can disable a voucher even though it's within the active period defined by the `start_date` and `expiration_date`.  \n\n- `true` indicates an *active* voucher\n- `false` indicates an *inactive* voucher"
+              },
+              "additional_info": {
+                "type": "string",
+                "description": "An optional field to keep any extra textual information about the code such as a code description and details.",
+                "nullable": true
+              },
+              "metadata": {
+                "title": "RedemptionRedeemVoucherMetadata",
                 "type": "object",
+                "description": "The metadata object stores all custom attributes assigned to the code. A set of key/value pairs that you can attach to a voucher object. It can be useful for storing additional information about the voucher in a structured format.",
+                "nullable": true
+              },
+              "assets": {
+                "$ref": "#/components/schemas/VoucherAssets"
+              },
+              "is_referral_code": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "Flag indicating whether this voucher is a referral code; `true` for campaign type `REFERRAL_PROGRAM`."
+              },
+              "created_at": {
+                "type": "string",
+                "example": "2021-12-22T10:13:06.487Z",
+                "description": "Timestamp representing the date and time when the voucher was created. The value is shown in the ISO 8601 format.",
+                "format": "date-time",
+                "nullable": true
+              },
+              "updated_at": {
+                "type": "string",
+                "example": "2021-12-22T10:14:45.316Z",
+                "format": "date-time",
+                "description": "Timestamp representing the date and time when the voucher was last updated in ISO 8601 format.",
+                "nullable": true
+              },
+              "holder_id": {
+                "type": "string",
+                "example": "cust_eWgXlBBiY6THFRJwX45Iakv4",
+                "description": "Unique customer identifier of the redeemable holder. It equals to the customer ID assigned by Voucherify.",
+                "nullable": true
+              },
+              "referrer_id": {
+                "type": "string",
+                "description": "Unique identifier of the referring person.",
+                "example": "cust_Vzck5i8U3OhcEUFY6MKhN9Rv",
+                "nullable": true
+              },
+              "object": {
+                "type": "string",
+                "description": "The type of the object represented by JSON. Default is `voucher`.",
+                "default": "voucher",
+                "nullable": true
+              },
+              "publish": {
+                "title": "RedemptionRedeemVoucherPublish",
+                "type": "object",
+                "description": "Stores a summary of publication events: an event counter and endpoint to return details of each event. Publication is an assignment of a code to a customer, e.g. through a distribution.",
                 "properties": {
-                  "redemptions": {
-                    "title": "RedemptionEntryPromotionTierSummaryRedemptions",
-                    "type": "object",
-                    "properties": {
-                      "total_redeemed": {
-                        "type": "integer",
-                        "description": "Number of times the promotion tier was redeemed.",
-                        "nullable": true
-                      }
-                    },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the `url` attribute.",
                     "nullable": true
                   },
-                  "orders": {
-                    "title": "RedemptionEntryPromotionTierSummaryOrders",
-                    "type": "object",
-                    "properties": {
-                      "total_amount": {
-                        "type": "integer",
-                        "description": "Sum of order totals.",
-                        "nullable": true
-                      },
-                      "total_discount_amount": {
-                        "type": "integer",
-                        "description": "Sum of total discount applied using the promotion tier.",
-                        "nullable": true
-                      }
-                    },
+                  "count": {
+                    "type": "integer",
+                    "example": 0,
+                    "description": "Publication events counter.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/publications?page=1&limit=10",
+                    "description": "The endpoint where this list of publications can be accessed using a GET method. `/v1/vouchers/{voucher_code}/publications`",
                     "nullable": true
                   }
                 },
                 "nullable": true
               },
-              "object": {
-                "type": "string",
-                "default": "promotion_tier",
-                "description": "The type of the object represented by JSON. This object stores information about the promotion tier.",
-                "nullable": true
-              },
-              "validation_rule_assignments": {
-                "$ref": "#/components/schemas/ValidationRuleAssignmentsList"
-              },
-              "category_id": {
-                "type": "string",
-                "description": "Promotion tier category ID.",
-                "example": "cat_0c9da30e7116ba6bba",
+              "redemption": {
+                "title": "RedemptionRedeemVoucherRedemption",
+                "type": "object",
+                "description": "Stores a summary of redemptions that have been applied to the voucher.",
+                "properties": {
+                  "quantity": {
+                    "type": "integer",
+                    "description": "How many times a voucher can be redeemed. A `null` value means unlimited.",
+                    "nullable": true
+                  },
+                  "redeemed_quantity": {
+                    "type": "integer",
+                    "example": 1,
+                    "description": "How many times a voucher has already been redeemed.",
+                    "nullable": true
+                  },
+                  "redeemed_points": {
+                    "type": "integer",
+                    "example": 100000,
+                    "description": "Total loyalty points redeemed.",
+                    "nullable": true
+                  },
+                  "object": {
+                    "type": "string",
+                    "default": "list",
+                    "description": "The type of the object represented is by default `list`. To get this list, you need to make a call to the endpoint returned in the url attribute.",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "example": "/v1/vouchers/WVPblOYX/redemptions?page=1&limit=10",
+                    "description": "The endpoint where this list of redemptions can be accessed using a GET method. `/v1/vouchers/{voucher_code}/redemptions`",
+                    "nullable": true
+                  }
+                },
                 "nullable": true
               },
               "categories": {
-                "title": "RedemptionEntryPromotionTierCategories",
+                "title": "RedemptionRedeemVoucherCategories",
                 "type": "array",
+                "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/Category"
+                  "$ref": "#/components/schemas/CategoryStackingRulesType"
                 },
                 "nullable": true
+              },
+              "validation_rules_assignments": {
+                "$ref": "#/components/schemas/ValidationRulesAssignmentsList"
+              },
+              "holder": {
+                "$ref": "#/components/schemas/SimpleCustomer"
               }
             },
-            "nullable": true
-          },
-          "reward": {
-            "$ref": "#/components/schemas/RedemptionRewardResult"
-          },
-          "gift": {
-            "title": "RedemptionEntryGift",
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Amount subtracted from the gift card as a result of the redemption. The amount is expressed as the smallest currency unit (e.g. 100 cents for $1.00). and Amount returned to the gift card as a result of the redemption rollback and expressed as a negative integer. The amount is expressed as the smallest currency unit (e.g. -100 cents for $1.00 returned)."
-              }
-            },
-            "nullable": true
-          },
-          "loyalty_card": {
-            "title": "RedemptionEntryLoyaltyCard",
-            "type": "object",
-            "properties": {
-              "points": {
-                "type": "integer",
-                "nullable": true,
-                "description": "Number of points subtracted from the loyalty card as a result of the redemption. and Number of points being returned to the loyalty card for the reward redemption rollback. It is expressed as a negative integer."
-              }
-            },
-            "nullable": true
-          },
-          "reason": {
-            "type": "string",
-            "description": "System generated cause for the redemption being invalid in the context of the provided parameters.",
             "nullable": true
           }
-        }
+        },
+        "description": "This is an object representing a redemption for **POST** `v1/redemptions`, **POST** `v1/loyalties/{campaignId}/members/{memberId}/redemption`, **POST** `v1/loyalties/members/{memberId}/redemption`, **POST** `/client/v1/redemptions`."
       },
       "RedemptionRewardResult": {
         "title": "RedemptionRewardResult",

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -36628,7 +36628,7 @@
                 "type": "array",
                 "description": "Contains details about the category.",
                 "items": {
-                  "$ref": "#/components/schemas/CategoryStackingRulesType"
+                  "$ref": "#/components/schemas/CategoryWithStackingRulesType"
                 },
                 "nullable": true
               },


### PR DESCRIPTION
## Why

- `categories` should include `stacking_rules_type` only for **POST** `v1/redemptions` and **POST** `client/v1/redemptions`
- Redeem reward for `/v1/loyalties/{campaignId}/members/{memberId}/redemption` and `/v1/loyalties//members/{memberId}/redemption` does **not** return anything in the `categories` array – it's always empty

## How

The current `Redemption` schema is used 8 times – 4 times in POST redemption methods, 3 times in GET redemption method and 1 time in POST loyalties redemption, I thought it would be best to ensure as much schema reuse as possible. That's why there's a new schema `RedemptionBase`, which is used in the common part of the redemption responses; the `voucher` property with respective voucher schemas is added to `allOf`s in the following umbrella schemas:
- `RedemptionRedeem` for POST methods
- `Redemption` for GET methods
- `MembersRedemption` for POST loyalties redemption