### PR TITLE
PW – Backlog changes

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,10 @@
 
 Older changes in [DEPRECATED.md](deprecated/DEPRECATED.md)
 
+## 2024-10-17
+
+Fixed `security` field in the `/v1/exports/{export_Id}.get` path.
+
 ## 2024-10-11
 
 Changed the structure of the `ValidationRuleRules` schema. The recurrence of the schema caused performance issues with Readme pages that use the schema. Fixed by copying the schema and allowing 3 levels of nesting.

--- a/docs/reference-docs/CUSTOMERS-Customer-Activity-Object.md
+++ b/docs/reference-docs/CUSTOMERS-Customer-Activity-Object.md
@@ -693,9 +693,9 @@ All of:
 | status</br>`string` | <p>The validation status</p> Available values: `VALID`, `INVALID` |
 | created_at</br>`string` | <p>Timestamp representing the date and time when the validation was created. The value is shown in the ISO 8601 format.</p> **Example:** <p>2021-12-22T10:13:06.487Z</p> |
 | customer_id</br>`string` | <p>Unique customer ID of the customer making the purchase.</p> **Example:** <p>cust_7iUa6ICKyU6gH40dBU25kQU1</p> |
-| redeemables</br>`array` | <p>Lists validation results of each redeemable.</p> Array of [Applicable Redeemable](#applicable-redeemable) |
-| skipped_redeemables</br>`array` | <p>Lists validation results of each redeemable.</p> Array of [Inapplicable Redeemable](#inapplicable-redeemable) |
-| inapplicable_redeemables</br>`array` | <p>Lists validation results of each redeemable.</p> Array of [Skipped Redeemable](#skipped-redeemable) |
+| redeemables</br>`array` | <p>Lists validation results of each redeemable.</p> Array of: <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique identifier of the redeemable, assigned by Voucherify.</p></td></tr><tr><td style="text-align:left">type</br><code>string</code></td><td style="text-align:left"><p>Type of the redeemable.</p> Available values: <code>voucher</code>, <code>promotion_tier</code></td></tr></tbody></table> |
+| skipped_redeemables</br>`array` | <p>Lists validation results of each redeemable.</p> Array of: <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique identifier of the redeemable, assigned by Voucherify.</p></td></tr><tr><td style="text-align:left">type</br><code>string</code></td><td style="text-align:left"><p>Type of the redeemable.</p> Available values: <code>voucher</code>, <code>promotion_tier</code></td></tr></tbody></table> |
+| inapplicable_redeemables</br>`array` | <p>Lists validation results of each redeemable.</p> Array of: <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique identifier of the redeemable, assigned by Voucherify.</p></td></tr><tr><td style="text-align:left">type</br><code>string</code></td><td style="text-align:left"><p>Type of the redeemable.</p> Available values: <code>voucher</code>, <code>promotion_tier</code></td></tr></tbody></table> |
 
 ## Event Customer Redemption
 | Attributes |  Description |
@@ -1050,39 +1050,6 @@ Available values: `POINTS_ACCRUAL`, `POINTS_REDEMPTION`, `POINTS_REFUND`, `POINT
 | discount | See: [Discount](#discount) |
 | is_referral_code</br>`boolean` | <p>Flag indicating whether this voucher is a referral code; <code>true</code> for campaign type <code>REFERRAL_PROGRAM</code>.</p> |
 
-## Applicable Redeemable
-| Attributes |  Description |
-|:-----|:--------|
-| status</br>`string` | <p>Indicates whether the redeemable can be applied or not applied based on the validation rules.</p> Available values: `APPLICABLE` |
-| id</br>`string` | <p>Redeemable ID, i.e. the voucher code.</p> |
-| object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
-| order | See: [Order Calculated No Customer Data](#order-calculated-no-customer-data) |
-| applicable_to | See: [Applicable To Result List](#applicable-to-result-list) |
-| inapplicable_to | See: [Inapplicable To Result List](#inapplicable-to-result-list) |
-| result | <p>Specifies the redeemable's end effect on the order. This object is unique to each type of redeemable.</p> One of: [Coupon Code](#coupon-code), [Gift Card](#gift-card), [Loyalty Card](#loyalty-card), [Redeemable Result Promotion Tier](#redeemable-result-promotion-tier), [Promotion Stack](#promotion-stack) |
-| metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
-
-## Inapplicable Redeemable
-| Attributes |  Description |
-|:-----|:--------|
-| status</br>`string` | <p>Indicates whether the redeemable can be applied or not applied based on the validation rules.</p> Available values: `INAPPLICABLE` |
-| id</br>`string` | <p>Redeemable ID, i.e. the voucher code.</p> |
-| object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
-| result</br>`object` | <p>Includes the error object with details about the reason why the redeemable is inapplicable</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">error</td><td style="text-align:left">See: <a href="#error-object">Error Object</a></td></tr><tr><td style="text-align:left">details</br><code>object</code></td><td style="text-align:left"><p>Provides details about the reason why the redeemable is inapplicable.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">message</br><code>string</code></td><td style="text-align:left"><p>Generic message from the <code>message</code> string shown in the <code>error</code> object or the message configured in a validation rule.</p></td></tr><tr><td style="text-align:left">key</br><code>string</code></td><td style="text-align:left"><p>Generic message from the <code>key</code> string shown in the <code>error</code> object.</p></td></tr></tbody></table></td></tr></tbody></table> |
-| metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
-
-## Skipped Redeemable
-| Attributes |  Description |
-|:-----|:--------|
-| status</br>`string` | <p>Indicates whether the redeemable can be applied or not applied based on the validation rules.</p> Available values: `SKIPPED` |
-| id</br>`string` | <p>Redeemable ID, i.e. the voucher code.</p> |
-| object</br>`string` | <p>Redeemable's object type.</p> Available values: `voucher`, `promotion_tier` |
-| result</br>`object` | <p>Provides details about the reason why the redeemable is skipped.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">details</td><td style="text-align:left">One of: <a href="#validations-redeemable-skipped-result-limit-exceeded">Validations Redeemable Skipped Result Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-category-limit-exceeded">Validations Redeemable Skipped Result Category Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-redeemables-limit-exceeded">Validations Redeemable Skipped Result Redeemables Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-redeemables-category-limit-exceeded">Validations Redeemable Skipped Result Redeemables Category Limit Exceeded</a>, <a href="#validations-redeemable-skipped-result-exclusion-rules-not-met">Validations Redeemable Skipped Result Exclusion Rules Not Met</a>, <a href="#validations-redeemable-skipped-result-preceding-validation-failed">Validations Redeemable Skipped Result Preceding Validation Failed</a></td></tr></tbody></table> |
-| metadata</br>`object` | <p>The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable.</p> |
-| categories</br>`array` | Array of [Category](#category) |
-
 ## Simple Order
 | Attributes |  Description |
 |:-----|:--------|
@@ -1332,94 +1299,6 @@ One of:
 ## Earning Rule Event
 
 
-## Applicable To Result List
-| Attributes |  Description |
-|:-----|:--------|
-| data</br>`array` | <p>Contains array of items to which the discount can apply.</p> Array of [Applicable To](#applicable-to) |
-| total</br>`integer` | <p>Total number of objects defining included products, SKUs, or product collections.</p> |
-| object</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `list` |
-| data_ref</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `data` |
-
-## Inapplicable To Result List
-| Attributes |  Description |
-|:-----|:--------|
-| data</br>`array` | <p>Contains array of items to which the discount cannot apply.</p> Array of [Inapplicable To](#inapplicable-to) |
-| total</br>`integer` | <p>Total number of objects defining included products, SKUs, or product collections.</p> |
-| object</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `list` |
-| data_ref</br>`string` | <p>The type of the object represented by JSON.</p> Available values: `data` |
-
-## Coupon Code
-| Attributes |  Description |
-|:-----|:--------|
-| discount | <p>Discount details about the type of discount to be applied for the redeemable.</p> One of: [Amount](#amount), [Unit](#unit), [Unit Multiple](#unit-multiple), [Percent](#percent), [Fixed](#fixed) |
-
-## Gift Card
-| Attributes |  Description |
-|:-----|:--------|
-| gift</br>`object` | <p>Stores the amount of gift card credits to be applied in the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">credits</br><code>integer</code></td><td style="text-align:left"><p>Total number of gift card credits to be applied in the redemption expressed as the smallest currency unit (e.g. 100 cents for $1.00).</p></td></tr></tbody></table> |
-
-## Loyalty Card
-| Attributes |  Description |
-|:-----|:--------|
-| loyalty_card</br>`object` | <p>Stores the amount of loyalty card points to be applied in the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Total number of loyalty points to be applied in the redemption.</p></td></tr></tbody></table> |
-
-## Redeemable Result Promotion Tier
-| Attributes |  Description |
-|:-----|:--------|
-| discount | <p>Discount details about the type of discount to be applied for the redeemable.</p> One of: [Amount](#amount), [Unit](#unit), [Unit Multiple](#unit-multiple), [Percent](#percent), [Fixed](#fixed) |
-
-## Promotion Stack
-| Attributes |  Description |
-|:-----|:--------|
-| loyalty_card</br>`object` | <p>Stores the amount of loyalty card points to be applied in the redemption.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Total number of loyalty points to be applied in the redemption.</p></td></tr></tbody></table> |
-
-## Error Object
-| Attributes |  Description |
-|:-----|:--------|
-| code</br>`integer` | <p>Error's HTTP status code.</p> |
-| key</br>`string` | <p>Short string describing the kind of error which occurred.</p> |
-| message</br>`string` | <p>A human-readable message providing a short description of the error.</p> |
-| details</br>`string` | <p>A human-readable message providing more details about the error.</p> |
-| request_id</br>`string` | <p>This ID is useful when troubleshooting and/or finding the root cause of an error response by our support team.</p> **Example:** <p>v-0a885062c80375740f</p> |
-| resource_id</br>`string` | <p>Unique resource ID that can be used in another endpoint to get more details.</p> **Example:** <p>rf_0c5d710a87c8a31f86</p> |
-| resource_type</br>`string` | <p>The resource type.</p> **Example:** <p>voucher</p> |
-
-## Validations Redeemable Skipped Result Limit Exceeded
-| Attributes |  Description |
-|:-----|:--------|
-| key</br>`string` | Available values: `applicable_redeemables_limit_exceeded` |
-| message</br>`string` | **Example:** <p>Applicable redeemables limit exceeded</p> |
-
-## Validations Redeemable Skipped Result Category Limit Exceeded
-| Attributes |  Description |
-|:-----|:--------|
-| key</br>`string` | Available values: `applicable_redeemables_per_category_limit_exceeded` |
-| message</br>`string` | **Example:** <p>Applicable redeemables limit per category exceeded</p> |
-
-## Validations Redeemable Skipped Result Redeemables Limit Exceeded
-| Attributes |  Description |
-|:-----|:--------|
-| key</br>`string` | Available values: `applicable_exclusive_redeemables_limit_exceeded` |
-| message</br>`string` | **Example:** <p>Applicable exclusive redeemables limit exceeded</p> |
-
-## Validations Redeemable Skipped Result Redeemables Category Limit Exceeded
-| Attributes |  Description |
-|:-----|:--------|
-| key</br>`string` | Available values: `applicable_exclusive_redeemables_per_category_limit_exceeded` |
-| message</br>`string` | **Example:** <p>Applicable exclusive redeemables limit per category exceeded</p> |
-
-## Validations Redeemable Skipped Result Exclusion Rules Not Met
-| Attributes |  Description |
-|:-----|:--------|
-| key</br>`string` | Available values: `exclusion_rules_not_met` |
-| message</br>`string` | **Example:** <p>Redeemable cannot be applied due to exclusion rules</p> |
-
-## Validations Redeemable Skipped Result Preceding Validation Failed
-| Attributes |  Description |
-|:-----|:--------|
-| key</br>`string` | Available values: `preceding_validation_failed` |
-| message</br>`string` | **Example:** <p>Redeemable cannot be applied due to preceding validation failure</p> |
-
 ## Simple Order Item
 | Attributes |  Description |
 |:-----|:--------|
@@ -1579,30 +1458,6 @@ One of:
 | calculation_type</br>`string` | <p>CUSTOM_EVENT_METADATA: Custom event metadata (X points for every Y in metadata attribute).</p> Available values: `CUSTOM_EVENT_METADATA` |
 | custom_event</br>`object` | <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">metadata</br><code>object</code></td><td style="text-align:left"><p>Defines the ratio based on the property defined in the calculation_type parameter. For every given increment of value (1, 10, etc) defined in the every parameter for the property defined in calculation_type, give the customer the number of points defined in the points parameter. In other words, for every order metadata property value, give points.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">every</br><code>integer</code></td><td style="text-align:left"><p>For how many increments of the customer metadata property to grant points for.</p></td></tr><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Number of points to be awarded, i.e. how many points to be added to the loyalty card.</p></td></tr><tr><td style="text-align:left">property</br><code>string</code></td><td style="text-align:left"><p>Custom event metadata property.</p></td></tr></tbody></table></td></tr></tbody></table> |
 
-## Applicable To
-| Attributes |  Description |
-|:-----|:--------|
-| object</br>`string` | <p>This object stores information about the resource to which the discount is applicable.</p> Available values: `product`, `sku`, `products_collection` |
-| id</br>`string` | <p>Unique product collection, product, or SKU identifier assigned by Voucherify.</p> |
-| source_id</br>`string` | <p>The source identifier from your inventory system.</p> |
-| product_id</br>`string` | <p>Parent product's unique ID assigned by Voucherify.</p> |
-| product_source_id</br>`string` | <p>Parent product's source ID from your inventory system.</p> |
-| strict</br>`boolean` |  |
-| price</br>`number` | <p>New fixed price of an item. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $10 price is written as 1000. In case of the fixed price being calculated by the formula, i.e. the price_formula parameter is present in the fixed price definition, this value becomes the fallback value. Such that in a case where the formula cannot be calculated due to missing metadata, for example, this value will be used as the fixed price.</p> |
-| price_formula</br>`number` | <p>Formula used to calculate the discounted price of an item.</p> |
-| effect | <p>Defines how the discount is applied to the customer's order.</p> [Applicable To Effect](#applicable-to-effect) |
-| quantity_limit</br>`integer` | <p>The maximum number of units allowed to be discounted per order line item.</p> |
-| aggregated_quantity_limit</br>`integer` | <p>The maximum number of units allowed to be discounted combined across all matched order line items.</p> |
-| amount_limit</br>`integer` | <p>Upper limit allowed to be applied as a discount per order line item. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount is written as 600.</p> |
-| aggregated_amount_limit</br>`integer` | <p>Maximum discount amount per order. Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $6 maximum discount on the entire order is written as 600. This value is definable for the following discount effects:</p><ul><li><code>APPLY_TO_ITEMS</code> (each item subtotal is discounted equally)</li><li><code>APPLY_TO_ITEMS_BY_QUANTITY</code> (each unit of matched products has the same discount value)</li></ul> |
-| order_item_indices</br>`array` | <p>Determines the order in which the discount is applied to the products or SKUs sent in the <code>order</code> object in the request. The counting begins from <code>0</code>.</p> |
-| repeat</br>`integer` | <p>Determines the recurrence of the discount, e.g. <code>&quot;repeat&quot;: 3</code> means that the discount is applied to every third item.</p> |
-| skip_initially</br>`integer` | <p>Determines how many items are skipped before the discount is applied.</p> |
-| target</br>`string` | <p>Determines to which kinds of objects the discount is applicable. <code>&quot;ITEM&quot;</code> includes products and SKUs.</p> Available values: `ITEM` |
-
-## Inapplicable To
-[Applicable To](#applicable-to)
-
 ## Order Amount
 | Attributes |  Description |
 |:-----|:--------|
@@ -1644,9 +1499,6 @@ One of:
 | type</br>`string` | <p>Defines how the points will be added to the loyalty card.PROPORTIONAL adds points based on a pre-defined ratio.</p> Available values: `PROPORTIONAL` |
 | calculation_type</br>`string` | <p>ORDER_ITEMS_SUBTOTAL_AMOUNT; Amount spent on items defined in the order_items.subtotal_amount.object &amp; .id (X points for every Y spent on items including discounts)</p> Available values: `ORDER_ITEMS_SUBTOTAL_AMOUNT` |
 | order_items</br>`object` | <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">subtotal_amount</br><code>object</code></td><td style="text-align:left"><p>Defines the ratio based on the property defined in the calculation_type parameter. For every set of value (1, 10, etc) defined in the every parameter for the property defined in calculation_type, give the customer the number of points defined in the points parameter. In other words, for every calculation_type, give points.</p> <table><thead><tr><th style="text-align:left">Attributes</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">every</br><code>integer</code></td><td style="text-align:left"><p>Value is multiplied by 100 to precisely represent 2 decimal places. For example, a $10 order amount is written as 1000.</p></td></tr><tr><td style="text-align:left">points</br><code>integer</code></td><td style="text-align:left"><p>Number of points to be awarded, i.e. how many points to be added to the loyalty card.</p></td></tr><tr><td style="text-align:left">object</br><code>string</code></td><td style="text-align:left"><p>Type of object taken under consideration.</p> Available values: <code>products_collection</code>, <code>product</code>, <code>sku</code></td></tr><tr><td style="text-align:left">id</br><code>string</code></td><td style="text-align:left"><p>Unique ID of the resource, i.e. pc_75U0dHlr7u75BJodrW1AE3t6, prod_0bae32322150fd0546, or sku_0b7d7dfb090be5c619.</p></td></tr></tbody></table></td></tr></tbody></table> |
-
-## Applicable To Effect
-Available values: `APPLY_TO_EVERY`, `APPLY_TO_CHEAPEST`, `APPLY_FROM_CHEAPEST`, `APPLY_TO_MOST_EXPENSIVE`, `APPLY_FROM_MOST_EXPENSIVE`
 
 [block:html]
 {

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -58704,7 +58704,14 @@
                 },
                 "examples": {
                   "Example": {
-                    "value": {}
+                    "value": {
+                      "id": "camp_tpl_0f887664cfe19f2162",
+                      "name": "Template Halloween Campaigns",
+                      "description": "Reuse every October",
+                      "campaign_type": "DISCOUNT_COUPONS",
+                      "created_at": "2024-10-17T14:37:59.488Z",
+                      "object": "campaign_template"
+                    }
                   }
                 }
               }

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -25106,7 +25106,22 @@
             "type": "array",
             "description": "Lists validation results of each redeemable.",
             "items": {
-              "$ref": "#/components/schemas/ValidationsRedeemableApplicable"
+              "type": "object",
+              "description": "Determines the redeemables",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the redeemable, assigned by Voucherify."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the redeemable.",
+                  "enum": [
+                    "voucher",
+                    "promotion_tier"
+                  ]
+                }
+              }
             },
             "nullable": true
           },
@@ -25114,7 +25129,22 @@
             "type": "array",
             "description": "Lists validation results of each redeemable.",
             "items": {
-              "$ref": "#/components/schemas/ValidationsRedeemableInapplicable"
+              "type": "object",
+              "description": "Determines the redeemables",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the redeemable, assigned by Voucherify."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the redeemable.",
+                  "enum": [
+                    "voucher",
+                    "promotion_tier"
+                  ]
+                }
+              }
             },
             "nullable": true
           },
@@ -25122,7 +25152,22 @@
             "type": "array",
             "description": "Lists validation results of each redeemable.",
             "items": {
-              "$ref": "#/components/schemas/ValidationsRedeemableSkipped"
+              "type": "object",
+              "description": "Determines the redeemables",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the redeemable, assigned by Voucherify."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the redeemable.",
+                  "enum": [
+                    "voucher",
+                    "promotion_tier"
+                  ]
+                }
+              }
             },
             "nullable": true
           }

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -29990,21 +29990,66 @@
             "type": "array",
             "description": "Lists validation results of each redeemable.",
             "items": {
-              "$ref": "#/components/schemas/ValidationsRedeemableApplicable"
+              "type": "object",
+              "description": "Determines the redeemables",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the redeemable, assigned by Voucherify."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the redeemable.",
+                  "enum": [
+                    "voucher",
+                    "promotion_tier"
+                  ]
+                }
+              }
             }
           },
           "skipped_redeemables": {
             "type": "array",
             "description": "Lists validation results of each redeemable.",
             "items": {
-              "$ref": "#/components/schemas/ValidationsRedeemableInapplicable"
+              "type": "object",
+              "description": "Determines the redeemables",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the redeemable, assigned by Voucherify."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the redeemable.",
+                  "enum": [
+                    "voucher",
+                    "promotion_tier"
+                  ]
+                }
+              }
             }
           },
           "inapplicable_redeemables": {
             "type": "array",
             "description": "Lists validation results of each redeemable.",
             "items": {
-              "$ref": "#/components/schemas/ValidationsRedeemableSkipped"
+              "type": "object",
+              "description": "Determines the redeemables",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the redeemable, assigned by Voucherify."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the redeemable.",
+                  "enum": [
+                    "voucher",
+                    "promotion_tier"
+                  ]
+                }
+              }
             }
           }
         }

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -83644,7 +83644,14 @@
                 },
                 "examples": {
                   "Example": {
-                    "value": {}
+                    "value": {
+                      "id": "camp_tpl_0f887664cfe19f2162",
+                      "name": "Template Halloween Campaigns",
+                      "description": "Reuse every October",
+                      "campaign_type": "DISCOUNT_COUPONS",
+                      "created_at": "2024-10-17T14:37:59.488Z",
+                      "object": "campaign_template"
+                    }
                   }
                 }
               }

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -71566,7 +71566,14 @@
                 },
                 "examples": {
                   "Example": {
-                    "value": {}
+                    "value": {
+                      "id": "camp_tpl_0f887664cfe19f2162",
+                      "name": "Template Halloween Campaigns",
+                      "description": "Reuse every October",
+                      "campaign_type": "DISCOUNT_COUPONS",
+                      "created_at": "2024-10-17T14:37:59.488Z",
+                      "object": "campaign_template"
+                    }
                   }
                 }
               }

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -72872,7 +72872,14 @@
                 },
                 "examples": {
                   "Example": {
-                    "value": {}
+                    "value": {
+                      "id": "camp_tpl_0f887664cfe19f2162",
+                      "name": "Template Halloween Campaigns",
+                      "description": "Reuse every October",
+                      "campaign_type": "DISCOUNT_COUPONS",
+                      "created_at": "2024-10-17T14:37:59.488Z",
+                      "object": "campaign_template"
+                    }
                   }
                 }
               }

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -71020,7 +71020,14 @@
                 },
                 "examples": {
                   "Example": {
-                    "value": {}
+                    "value": {
+                      "id": "camp_tpl_0f887664cfe19f2162",
+                      "name": "Template Halloween Campaigns",
+                      "description": "Reuse every October",
+                      "campaign_type": "DISCOUNT_COUPONS",
+                      "created_at": "2024-10-17T14:37:59.488Z",
+                      "object": "campaign_template"
+                    }
                   }
                 }
               }

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -71704,7 +71704,14 @@
                 },
                 "examples": {
                   "Example": {
-                    "value": {}
+                    "value": {
+                      "id": "camp_tpl_0f887664cfe19f2162",
+                      "name": "Template Halloween Campaigns",
+                      "description": "Reuse every October",
+                      "campaign_type": "DISCOUNT_COUPONS",
+                      "created_at": "2024-10-17T14:37:59.488Z",
+                      "object": "campaign_template"
+                    }
                   }
                 }
               }

--- a/scripts/prepare-open-api-for-sdk/index.ts
+++ b/scripts/prepare-open-api-for-sdk/index.ts
@@ -111,6 +111,10 @@ const main = async (languageOptions: LanguageOptions) => {
     .properties;
   //Do not do breaking change in `ApplicableTo`
   delete openAPIContent.components.schemas.ApplicableTo.properties.target.enum;
+  //Delete `enum`s for redeemables in `ValidationEntity`
+  delete openAPIContent.components.schemas.ValidationEntity.properties.redeemables.items.properties.type.enum;
+  delete openAPIContent.components.schemas.ValidationEntity.properties.skipped_redeemables.items.properties.type.enum;
+  delete openAPIContent.components.schemas.ValidationEntity.properties.inapplicable_redeemables.items.properties.type.enum;
   //ValidationRuleRules fix for Readme – should stay forever
   openAPIContent.components.schemas.ValidationRuleRules.additionalProperties.properties.rules.$ref = "#/components/schemas/ValidationRuleRules"
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What

Various minor fixes and updates to OpenAPI.json

- Fix to the `ValidationEntity` schema, as the `redeemables`, `skipped_redeemables`, and `inapplicable_redeemables` return only `id` and `type` in the `customer.validation.succeeded` and `customer.validation.failed` events.
- Add a 200 response example to **POST** `v1/templates/campaigns`