### PR TITLE
PW – Schema name change

### DIFF
--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -20989,7 +20989,7 @@
         "title": "Redemption Entry",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/RedemptionWithVoucherWithStackingRulesTypeCategories"
+            "$ref": "#/components/schemas/RedemptionWithVoucherWithoutStackingRulesTypeCategories"
           },
           {
             "$ref": "#/components/schemas/RedemptionRollback"
@@ -21614,7 +21614,7 @@
       "RedemptionsGetResponseBody": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/RedemptionWithVoucherWithStackingRulesTypeCategories"
+            "$ref": "#/components/schemas/RedemptionWithVoucherWithoutStackingRulesTypeCategories"
           },
           {
             "$ref": "#/components/schemas/RedemptionRollback"
@@ -21646,7 +21646,7 @@
               "title": "Redemptions List Response Body Redemptions Item",
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/RedemptionWithVoucherWithStackingRulesTypeCategories"
+                  "$ref": "#/components/schemas/RedemptionWithVoucherWithoutStackingRulesTypeCategories"
                 },
                 {
                   "$ref": "#/components/schemas/RedemptionRollback"
@@ -21826,7 +21826,7 @@
           }
         }
       },
-      "RedemptionWithVoucherWithStackingRulesTypeCategories": {
+      "RedemptionWithVoucherWithoutStackingRulesTypeCategories": {
         "title": "Redemption",
         "type": "object",
         "description": "This is an object representing a redemption.",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -17827,7 +17827,7 @@
           }
         ]
       },
-      "RedemptionWithVoucherWithStackingRulesTypeCategories": {
+      "RedemptionWithVoucherWithoutStackingRulesTypeCategories": {
         "title": "Redemption",
         "type": "object",
         "description": "This is an object representing a redemption.",
@@ -21337,7 +21337,7 @@
       "RedemptionsGetResponseBody": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/RedemptionWithVoucherWithStackingRulesTypeCategories"
+            "$ref": "#/components/schemas/RedemptionWithVoucherWithoutStackingRulesTypeCategories"
           },
           {
             "$ref": "#/components/schemas/RedemptionRollback"
@@ -21367,7 +21367,7 @@
               "title": "Redemptions List Response Body Redemptions Item",
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/RedemptionWithVoucherWithStackingRulesTypeCategories"
+                  "$ref": "#/components/schemas/RedemptionWithVoucherWithoutStackingRulesTypeCategories"
                 },
                 {
                   "$ref": "#/components/schemas/RedemptionRollback"
@@ -39092,7 +39092,7 @@
         "title": "Redemption Entry",
         "oneOf": [
           {
-            "$ref": "#/components/schemas/RedemptionWithVoucherWithStackingRulesTypeCategories"
+            "$ref": "#/components/schemas/RedemptionWithVoucherWithoutStackingRulesTypeCategories"
           },
           {
             "$ref": "#/components/schemas/RedemptionRollback"


### PR DESCRIPTION
## Why

Was:
- `RedemptionWithVoucherWithStackingRulesTypeCategories`

Should be:
- `RedemptionWithVoucherWithoutStackingRulesTypeCategories`

because the `Voucher` schema there includes the `Category` schema **without** the `stacking_rules_type` property