### PR TITLE
PW – Remove `validation_rules` from Create Loyalty Campaign

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,10 @@
 
 Older changes in [DEPRECATED.md](deprecated/DEPRECATED.md)
 
+## 2024-12-03
+
+Remove `validation_rules` from Create Loyalty Campaign endpoints by swapping `CampaignsCreateBaseValidationRules` to `CampaignsCreateBase` in `CampaignsCreateLoyaltyCampaign`.
+
 ## 2024-11-26
 
 - Added the `metadata` object to the `sku` in:

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -2198,7 +2198,7 @@
         "title": "Create Loyalty Campaign",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CampaignsCreateBaseValidationRules"
+            "$ref": "#/components/schemas/CampaignsCreateBase"
           },
           {
             "type": "object",

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -20903,7 +20903,7 @@
           "limit": {
             "type": "integer",
             "description": "The maximum number of redeemables to be returned in the API request. The actual number of returned redeemables will be determined by the API. The default value is set to 5",
-            "maximum": 100,
+            "maximum": 50,
             "nullable": true
           },
           "starting_after": {

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -33833,7 +33833,7 @@
           "limit": {
             "type": "integer",
             "description": "The maximum number of redeemables to be returned in the API request. The actual number of returned redeemables will be determined by the API. The default value is set to 5",
-            "maximum": 100
+            "maximum": 50
           },
           "starting_after": {
             "type": "string",

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -9266,7 +9266,7 @@
         "title": "Create Loyalty Campaign",
         "allOf": [
           {
-            "$ref": "#/components/schemas/CampaignsCreateBaseValidationRules"
+            "$ref": "#/components/schemas/CampaignsCreateBase"
           },
           {
             "type": "object",

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -5127,17 +5127,6 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
-          "validation_rules": {
-            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
-            "type": "array",
-            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
-            "items": {
-              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
-              "type": "string"
-            },
-            "maxItems": 1,
-            "nullable": true
-          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -35178,7 +35178,7 @@
           "limit": {
             "type": "integer",
             "description": "The maximum number of redeemables to be returned in the API request. The actual number of returned redeemables will be determined by the API. The default value is set to 5",
-            "maximum": 100,
+            "maximum": 50,
             "nullable": true
           },
           "starting_after": {

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -5127,6 +5127,17 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
+          "validation_rules": {
+            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
+            "type": "array",
+            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
+            "items": {
+              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
+              "type": "string"
+            },
+            "maxItems": 1,
+            "nullable": true
+          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -5255,6 +5255,17 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
+          "validation_rules": {
+            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
+            "type": "array",
+            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
+            "items": {
+              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
+              "type": "string"
+            },
+            "maxItems": 1,
+            "nullable": true
+          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -5255,17 +5255,6 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
-          "validation_rules": {
-            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
-            "type": "array",
-            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
-            "items": {
-              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
-              "type": "string"
-            },
-            "maxItems": 1,
-            "nullable": true
-          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -36263,7 +36263,7 @@
           "limit": {
             "type": "integer",
             "description": "The maximum number of redeemables to be returned in the API request. The actual number of returned redeemables will be determined by the API. The default value is set to 5",
-            "maximum": 100,
+            "maximum": 50,
             "nullable": true
           },
           "starting_after": {

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -5127,17 +5127,6 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
-          "validation_rules": {
-            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
-            "type": "array",
-            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
-            "items": {
-              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
-              "type": "string"
-            },
-            "maxItems": 1,
-            "nullable": true
-          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -5127,6 +5127,17 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
+          "validation_rules": {
+            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
+            "type": "array",
+            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
+            "items": {
+              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
+              "type": "string"
+            },
+            "maxItems": 1,
+            "nullable": true
+          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -34630,7 +34630,7 @@
           "limit": {
             "type": "integer",
             "description": "The maximum number of redeemables to be returned in the API request. The actual number of returned redeemables will be determined by the API. The default value is set to 5",
-            "maximum": 100,
+            "maximum": 50,
             "nullable": true
           },
           "starting_after": {

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -5161,6 +5161,17 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
+          "validation_rules": {
+            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
+            "type": "array",
+            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
+            "items": {
+              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
+              "type": "string"
+            },
+            "maxItems": 1,
+            "nullable": true
+          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -35212,7 +35212,7 @@
           "limit": {
             "type": "integer",
             "description": "The maximum number of redeemables to be returned in the API request. The actual number of returned redeemables will be determined by the API. The default value is set to 5",
-            "maximum": 100,
+            "maximum": 50,
             "nullable": true
           },
           "starting_after": {

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -5161,17 +5161,6 @@
             "description": "The metadata object stores all custom attributes assigned to the campaign. A set of key/value pairs that you can attach to a campaign object. It can be useful for storing additional information about the campaign in a structured format.",
             "nullable": true
           },
-          "validation_rules": {
-            "title": "LoyaltiesCreateCampaignRequestBodyValidationRules",
-            "type": "array",
-            "description": "Array containing the ID of the validation rule associated with the promotion tier.",
-            "items": {
-              "title": "LoyaltiesCreateCampaignRequestBodyValidationRulesItem",
-              "type": "string"
-            },
-            "maxItems": 1,
-            "nullable": true
-          },
           "campaign_type": {
             "type": "string",
             "default": "LOYALTY_PROGRAM",

--- a/scripts/prepare-open-api-for-sdk/index.ts
+++ b/scripts/prepare-open-api-for-sdk/index.ts
@@ -113,6 +113,14 @@ const main = async (languageOptions: LanguageOptions) => {
         "title": "Any"
       }`);
   delete openAPIContent.components.schemas.AsyncActionBase.properties.type.enum;
+  //Restore validation_rules for creat loyalty campaigns
+  openAPIContent.components.schemas.CampaignsCreateLoyaltyCampaign.allOf.map((object) => {
+    if (object.$ref === "#/components/schemas/CampaignsCreateBase") {
+      return {
+        $ref: "#/components/schemas/CampaignsCreateBaseValidationRules",
+      };
+    } return object
+  })
   //Fix voucher - to prevent breaking changes
   delete openAPIContent.components.schemas.AsyncActionBase.properties.type.enum;
   delete openAPIContent.components.schemas.AsyncActionBase.properties

--- a/scripts/prepare-open-api-for-sdk/index.ts
+++ b/scripts/prepare-open-api-for-sdk/index.ts
@@ -114,13 +114,17 @@ const main = async (languageOptions: LanguageOptions) => {
       }`);
   delete openAPIContent.components.schemas.AsyncActionBase.properties.type.enum;
   //Restore validation_rules for creat loyalty campaigns
-  openAPIContent.components.schemas.CampaignsCreateLoyaltyCampaign.allOf.map((object) => {
-    if (object.$ref === "#/components/schemas/CampaignsCreateBase") {
-      return {
-        $ref: "#/components/schemas/CampaignsCreateBaseValidationRules",
-      };
-    } return object
-  })
+  openAPIContent.components.schemas.CampaignsCreateLoyaltyCampaign.allOf =
+    openAPIContent.components.schemas.CampaignsCreateLoyaltyCampaign.allOf.map(
+      (object) => {
+        if (object.$ref === "#/components/schemas/CampaignsCreateBase") {
+          return {
+            $ref: "#/components/schemas/CampaignsCreateBaseValidationRules",
+          };
+        }
+        return object;
+      },
+    );
   //Fix voucher - to prevent breaking changes
   delete openAPIContent.components.schemas.AsyncActionBase.properties.type.enum;
   delete openAPIContent.components.schemas.AsyncActionBase.properties


### PR DESCRIPTION
## What

Title

## How

Remove `validation_rules` from Create Loyalty Campaign endpoints by swapping `CampaignsCreateBaseValidationRules` to `CampaignsCreateBase` in `CampaignsCreateLoyaltyCampaign`.

## Also

Changed maximum from 100 to 50 in qualification QualificationsOption.limit