### PR TITLE
bump urllib3 dep in python templates

### DIFF
--- a/mustache-templates/python/README.mustache
+++ b/mustache-templates/python/README.mustache
@@ -26,7 +26,7 @@ You will find detailed description and example responses at our [official docume
 
 ## Requirements.
 
-Python 3.7+
+Python 3.9+
 
 ## Installation
 

--- a/mustache-templates/python/README_onlypackage.mustache
+++ b/mustache-templates/python/README_onlypackage.mustache
@@ -26,7 +26,7 @@ This python library package is generated without supporting files like setup.py 
 
 To be able to use it, you will need these dependencies in your own package that uses this library:
 
-* urllib3 >= 1.25.3
+* urllib3 >= 2.5.0
 * python-dateutil
 {{#asyncio}}
 * aiohttp

--- a/mustache-templates/python/github-workflow.mustache
+++ b/mustache-templates/python/github-workflow.mustache
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/mustache-templates/python/gitlab-ci.mustache
+++ b/mustache-templates/python/gitlab-ci.mustache
@@ -14,12 +14,6 @@ stages:
    - pip install -r test-requirements.txt
    - pytest --cov={{{packageName}}}
 
-pytest-3.7:
-  extends: .pytest
-  image: python:3.7-alpine
-pytest-3.8:
-  extends: .pytest
-  image: python:3.8-alpine
 pytest-3.9:
   extends: .pytest
   image: python:3.9-alpine

--- a/mustache-templates/python/pyproject.mustache
+++ b/mustache-templates/python/pyproject.mustache
@@ -12,7 +12,7 @@ include = ["{{packageName}}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-urllib3 = ">= 1.25.3"
+urllib3 = ">= 2.5.0"
 python-dateutil = ">=2.8.2"
 {{#asyncio}}
 aiohttp = ">= 3.8.4"

--- a/mustache-templates/python/pyproject.mustache
+++ b/mustache-templates/python/pyproject.mustache
@@ -10,7 +10,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"]
 include = ["{{packageName}}/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 
 urllib3 = ">= 2.5.0"
 python-dateutil = ">=2.8.2"

--- a/mustache-templates/python/requirements.mustache
+++ b/mustache-templates/python/requirements.mustache
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 2.5.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 {{#asyncio}}

--- a/mustache-templates/python/setup.mustache
+++ b/mustache-templates/python/setup.mustache
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # http://pypi.python.org/pypi/setuptools
 NAME = "{{{projectName}}}"
 VERSION = "{{packageVersion}}"
-PYTHON_REQUIRES = ">=3.7"
+PYTHON_REQUIRES = ">=3.9"
 {{#apiInfo}}
 {{#apis}}
 {{#-last}}

--- a/mustache-templates/python/setup.mustache
+++ b/mustache-templates/python/setup.mustache
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = ">=3.7"
 {{#apis}}
 {{#-last}}
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 2.5.0",
     "python-dateutil",
 {{#asyncio}}
     "aiohttp >= 3.0.0",

--- a/mustache-templates/python/travis.mustache
+++ b/mustache-templates/python/travis.mustache
@@ -1,8 +1,6 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
 python:
-  - "3.7"
-  - "3.8"
   - "3.9"
   - "3.10"
   - "3.11"


### PR DESCRIPTION
Updating version references for `urllib3` so the Voucherify client doesn't drag down the version resolved for integrating projects.

Tested here: https://github.com/voucherifyio/voucherify-python-sdk/pull/60