### PR TITLE
PHP SDK - Fixed PHP 8.4 deprecation warnings -> result in SDK  v5.0.4

### DIFF
--- a/mustache-templates/php-nextgen/.php-cs-fixer.dist.php
+++ b/mustache-templates/php-nextgen/.php-cs-fixer.dist.php
@@ -21,6 +21,7 @@ return $config->setRules([
         'no_trailing_whitespace' => false,
         'no_trailing_whitespace_in_comment' => false,
         'braces' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'single_blank_line_at_eof' => false,
         'blank_line_after_namespace' => false,
         'no_leading_import_slash' => false,

--- a/mustache-templates/php-nextgen/Configuration.mustache
+++ b/mustache-templates/php-nextgen/Configuration.mustache
@@ -502,7 +502,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, $hostIndex, array $variables = null)
+    public static function getHostString(array $hostsSettings, $hostIndex, ?array $variables = null)
     {
         if (null === $variables) {
             $variables = [];

--- a/mustache-templates/php-nextgen/api.mustache
+++ b/mustache-templates/php-nextgen/api.mustache
@@ -76,9 +76,9 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();

--- a/mustache-templates/php-nextgen/model_generic.mustache
+++ b/mustache-templates/php-nextgen/model_generic.mustache
@@ -234,7 +234,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         {{#parentSchema}}
         parent::__construct($data);


### PR DESCRIPTION
Changes needed to build new PHP SDK with Fixed PHP 8.4 deprecation warnings, more details here: https://github.com/voucherifyio/voucherify-php-sdk/pull/98