### PR TITLE
PW – Fix list rewards v2

### DIFF
--- a/documentation/openapi/loyalties-v2.json
+++ b/documentation/openapi/loyalties-v2.json
@@ -8425,7 +8425,7 @@
         "tags": [
           "Rewards"
         ],
-        "summary": "List rewards",
+        "summary": "List loyalty rewards",
         "description": "⚠️ **BETA endpoint**\n\nThis is a work-in-progress documentation of a BETA endpoint. The parameters, fields, request and response bodies, and other data may subject to change. If you want to share feedback or improvements, contact Voucherify support or your Technical Account Manager.\n\nReturns a cursor-paginated list of rewards. Results can be filtered by id, name,\ntype and created_at, and ordered by created_at or name (ascending or descending).\nThe same field cannot be ordered both ascending and descending at the same time.\n",
         "parameters": [
           {


### PR DESCRIPTION
## What

The same value of `summary` causes a mix up of v2 and v1 endpoints in the documentation.