### PR TITLE
DEV-4216 Typed `exchange_ratio` as `number` (was `integer`)

### DIFF
--- a/changelog/OPEN-API.md
+++ b/changelog/OPEN-API.md
@@ -4,6 +4,10 @@
 
 Older changes in [DEPRECATED.md](deprecated/DEPRECATED.md)
 
+## 2026-08-25
+
+Typed `exchange_ratio` as `number` (was `integer` on redemption/reward nested `coin` objects, and `string` on create/update Pay with Points reward request bodies). The API returns fractional values such as `0.01`.
+
 ## 2026-08-10
 
 Published Loyalty v2 API reference overview pages:

--- a/documentation/api-reference/customers/customer-activity-object.mdx
+++ b/documentation/api-reference/customers/customer-activity-object.mdx
@@ -12340,7 +12340,7 @@ mode: "frame"
                         <p>
                           exchange_ratio
                           <br />
-                          <code>integer</code>
+                          <code>number</code>
                         </p>
                       </td>
                       <td>

--- a/documentation/api-reference/redemptions/redemption-object.mdx
+++ b/documentation/api-reference/redemptions/redemption-object.mdx
@@ -2050,7 +2050,7 @@ mode: "frame"
                         <p>
                           exchange_ratio
                           <br />
-                          <code>integer</code>
+                          <code>number</code>
                         </p>
                       </td>
                       <td>

--- a/documentation/api-reference/redemptions/redemption-rollback-object.mdx
+++ b/documentation/api-reference/redemptions/redemption-rollback-object.mdx
@@ -2262,7 +2262,7 @@ mode: "frame"
                         <p>
                           exchange_ratio
                           <br />
-                          <code>integer</code>
+                          <code>number</code>
                         </p>
                       </td>
                       <td>

--- a/documentation/api-reference/redemptions/stackable-redemptions-object.mdx
+++ b/documentation/api-reference/redemptions/stackable-redemptions-object.mdx
@@ -3418,7 +3418,7 @@ mode: "frame"
                         <p>
                           exchange_ratio
                           <br />
-                          <code>integer</code>
+                          <code>number</code>
                         </p>
                       </td>
                       <td>

--- a/documentation/openapi-events/events-customer.json
+++ b/documentation/openapi-events/events-customer.json
@@ -4404,7 +4404,7 @@
             "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "integer",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {

--- a/documentation/openapi-events/events-redemption.json
+++ b/documentation/openapi-events/events-redemption.json
@@ -1233,7 +1233,7 @@
             "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "integer",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {

--- a/documentation/openapi-events/events-voucher.json
+++ b/documentation/openapi-events/events-voucher.json
@@ -4684,7 +4684,7 @@
             "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "integer",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {

--- a/documentation/openapi/client-side.json
+++ b/documentation/openapi/client-side.json
@@ -7937,7 +7937,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {
@@ -9396,7 +9396,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/documentation/openapi/customers.json
+++ b/documentation/openapi/customers.json
@@ -9111,7 +9111,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/documentation/openapi/loyalties.json
+++ b/documentation/openapi/loyalties.json
@@ -21920,7 +21920,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/documentation/openapi/redemptions.json
+++ b/documentation/openapi/redemptions.json
@@ -7299,7 +7299,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {
@@ -9554,7 +9554,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/documentation/openapi/rewards.json
+++ b/documentation/openapi/rewards.json
@@ -1923,7 +1923,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {
@@ -2095,7 +2095,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {

--- a/production/readOnly-openAPI.json
+++ b/production/readOnly-openAPI.json
@@ -25166,7 +25166,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -26455,7 +26455,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                 "nullable": true
               },
@@ -26725,7 +26725,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                 "nullable": true
               },

--- a/reference/OpenAPI.json
+++ b/reference/OpenAPI.json
@@ -11909,7 +11909,7 @@
             "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "integer",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {
@@ -12264,7 +12264,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {
@@ -12400,7 +12400,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {
@@ -20500,7 +20500,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {
@@ -33217,7 +33217,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/reference/OpenAPIWebhooks-old.json
+++ b/reference/OpenAPIWebhooks-old.json
@@ -9507,7 +9507,7 @@
             "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "integer",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {

--- a/reference/OpenAPIWebhooks.json
+++ b/reference/OpenAPIWebhooks.json
@@ -149,7 +149,7 @@
             "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "integer",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {

--- a/reference/readonly-sdks/dotnet/OpenAPI.json
+++ b/reference/readonly-sdks/dotnet/OpenAPI.json
@@ -28562,7 +28562,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -28787,7 +28787,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -43256,7 +43256,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },

--- a/reference/readonly-sdks/java/OpenAPI.json
+++ b/reference/readonly-sdks/java/OpenAPI.json
@@ -28685,7 +28685,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -28913,7 +28913,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -43541,7 +43541,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },

--- a/reference/readonly-sdks/js/OpenAPI.json
+++ b/reference/readonly-sdks/js/OpenAPI.json
@@ -28878,7 +28878,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -29106,7 +29106,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -43734,7 +43734,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },

--- a/reference/readonly-sdks/php/OpenAPI.json
+++ b/reference/readonly-sdks/php/OpenAPI.json
@@ -27430,7 +27430,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -27658,7 +27658,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -41982,7 +41982,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },

--- a/reference/readonly-sdks/python/OpenAPI.json
+++ b/reference/readonly-sdks/python/OpenAPI.json
@@ -28428,7 +28428,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -28656,7 +28656,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -42918,7 +42918,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },

--- a/reference/readonly-sdks/ruby/OpenAPI.json
+++ b/reference/readonly-sdks/ruby/OpenAPI.json
@@ -26649,7 +26649,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -26877,7 +26877,7 @@
                 "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "string",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },
@@ -40786,7 +40786,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property.",
                     "nullable": true
                   },

--- a/reference/split-openapi-by-tags/client-side.json
+++ b/reference/split-openapi-by-tags/client-side.json
@@ -7878,7 +7878,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {
@@ -9337,7 +9337,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/reference/split-openapi-by-tags/customers.json
+++ b/reference/split-openapi-by-tags/customers.json
@@ -9072,7 +9072,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/reference/split-openapi-by-tags/loyalties.json
+++ b/reference/split-openapi-by-tags/loyalties.json
@@ -21136,7 +21136,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/reference/split-openapi-by-tags/redemptions.json
+++ b/reference/split-openapi-by-tags/redemptions.json
@@ -7275,7 +7275,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {
@@ -9512,7 +9512,7 @@
                 "description": "Defines the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
                 "properties": {
                   "exchange_ratio": {
-                    "type": "integer",
+                    "type": "number",
                     "description": "The cash equivalent of the points defined in the `points_ratio` property."
                   },
                   "points_ratio": {

--- a/reference/split-openapi-by-tags/rewards.json
+++ b/reference/split-openapi-by-tags/rewards.json
@@ -1899,7 +1899,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {
@@ -2071,7 +2071,7 @@
             "description": "Define the ratio by mapping the number of loyalty points in `points_ratio` to a predefined cash amount in `exchange_ratio`.",
             "properties": {
               "exchange_ratio": {
-                "type": "string",
+                "type": "number",
                 "description": "The cash equivalent of the points defined in the `points_ratio` property."
               },
               "points_ratio": {


### PR DESCRIPTION
Issue reported by Kasjan:

https://voucherify.atlassian.net/browse/DEV-4216